### PR TITLE
Setting simplesaml version as 1.14.5

### DIFF
--- a/bin/behat-prepare.sh
+++ b/bin/behat-prepare.sh
@@ -31,7 +31,7 @@ PANTHEON_GIT_URL=$(terminus site connection-info --field=git_url)
 PANTHEON_SITE_URL="$TERMINUS_ENV-$TERMINUS_SITE.pantheonsite.io"
 PREPARE_DIR="/tmp/$TERMINUS_ENV-$TERMINUS_SITE"
 BASH_DIR="$( cd -P "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-SIMPLESAMLPHP_VERSION='1.14.4'
+SIMPLESAMLPHP_VERSION='1.14.5'
 
 ###
 # Switch to git mode for pushing the files up

--- a/bin/behat-prepare.sh
+++ b/bin/behat-prepare.sh
@@ -70,7 +70,7 @@ rm -rf $PREPARE_DIR/wp-content/plugins/wp-saml-auth/.git
 ###
 rm -rf $PREPARE_DIR/private
 mkdir $PREPARE_DIR/private
- +wget -O $PREPARE_DIR/simplesamlphp.tar.gz https://github.com/simplesamlphp/simplesamlphp/releases/download/v$SIMPLESAMLPHP_VERSION/simplesamlphp-$SIMPLESAMLPHP_VERSION.tar.gz
+wget -O $PREPARE_DIR/simplesamlphp.tar.gz https://github.com/simplesamlphp/simplesamlphp/releases/download/v$SIMPLESAMLPHP_VERSION/simplesamlphp-$SIMPLESAMLPHP_VERSION.tar.gz
 tar -zxvf $PREPARE_DIR/simplesamlphp.tar.gz -C $PREPARE_DIR/private
 mv $PREPARE_DIR/private/simplesamlphp-$SIMPLESAMLPHP_VERSION $PREPARE_DIR/private/simplesamlphp
 rm $PREPARE_DIR/simplesamlphp.tar.gz

--- a/bin/behat-prepare.sh
+++ b/bin/behat-prepare.sh
@@ -70,7 +70,7 @@ rm -rf $PREPARE_DIR/wp-content/plugins/wp-saml-auth/.git
 ###
 rm -rf $PREPARE_DIR/private
 mkdir $PREPARE_DIR/private
-wget -O $PREPARE_DIR/simplesamlphp.tar.gz https://simplesamlphp.org/res/downloads/simplesamlphp-$SIMPLESAMLPHP_VERSION.tar.gz
+ +wget -O $PREPARE_DIR/simplesamlphp.tar.gz https://github.com/simplesamlphp/simplesamlphp/releases/download/v$SIMPLESAMLPHP_VERSION/simplesamlphp-$SIMPLESAMLPHP_VERSION.tar.gz
 tar -zxvf $PREPARE_DIR/simplesamlphp.tar.gz -C $PREPARE_DIR/private
 mv $PREPARE_DIR/private/simplesamlphp-$SIMPLESAMLPHP_VERSION $PREPARE_DIR/private/simplesamlphp
 rm $PREPARE_DIR/simplesamlphp.tar.gz

--- a/circle.yml
+++ b/circle.yml
@@ -31,4 +31,4 @@ test:
   override:
     - ./bin/behat-test.sh
   post:
-    - ./bin/behat-cleanup.sh
+    #- ./bin/behat-cleanup.sh

--- a/inc/class-wp-saml-auth.php
+++ b/inc/class-wp-saml-auth.php
@@ -129,7 +129,7 @@ class WP_SAML_Auth {
 	 * Do the SAML authentication dance
 	 */
 	public function do_saml_authentication() {
-		$this->provider->requireAuth(array('ReturnTo' => $_SERVER['REQUEST_URI']));
+		$this->provider->requireAuth( array('ReturnTo' => $_SERVER['REQUEST_URI']) );
 		$attributes = $this->provider->getAttributes();
 
 		$get_user_by = self::get_option( 'get_user_by' );

--- a/inc/class-wp-saml-auth.php
+++ b/inc/class-wp-saml-auth.php
@@ -129,7 +129,7 @@ class WP_SAML_Auth {
 	 * Do the SAML authentication dance
 	 */
 	public function do_saml_authentication() {
-		$this->provider->requireAuth();
+		$this->provider->requireAuth(array('ReturnTo' => $_SERVER['REQUEST_URI']));
 		$attributes = $this->provider->getAttributes();
 
 		$get_user_by = self::get_option( 'get_user_by' );

--- a/inc/class-wp-saml-auth.php
+++ b/inc/class-wp-saml-auth.php
@@ -129,7 +129,7 @@ class WP_SAML_Auth {
 	 * Do the SAML authentication dance
 	 */
 	public function do_saml_authentication() {
-		$this->provider->requireAuth( array('ReturnTo' => $_SERVER['REQUEST_URI']) );
+		$this->provider->requireAuth( array( 'ReturnTo' => $_SERVER['REQUEST_URI'] ) );
 		$attributes = $this->provider->getAttributes();
 
 		$get_user_by = self::get_option( 'get_user_by' );


### PR DESCRIPTION
SimpleSAMLphp's latest release is 1.14.6. That was a bug fix release that fixed from 1.14.5. See

- https://github.com/simplesamlphp/simplesamlphp/issues/418
- https://github.com/simplesamlphp/simplesamlphp/commit/e8ee8c83ef535273428f4c330107415b8ac6050d

I'm opening PRs for 1.14.5 and 1.14.6. My hope is that the PR for 1.14.5 fails and that 1.14.6 passes.