### PR TITLE
Run Behat in strict mode

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -38,6 +38,6 @@ test:
   pre:
     - ./bin/behat-prepare.sh
   override:
-    - ./bin/behat-test.sh
+    - ./bin/behat-test.sh --strict
   post:
     - ./bin/behat-cleanup.sh


### PR DESCRIPTION
Doing so ensures any undefined steps will fail the build, instead of
permitting it to pass