### PR TITLE
setting terminus version number

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -30,7 +30,7 @@ dependencies:
         echo "TERMINUS_TOKEN environment variables missing; assuming unauthenticated build"
         exit 0
       fi
-      composer global require pantheon-systems/terminus
+      composer global require pantheon-systems/terminus "<0.13.0"
       composer install
       terminus auth login --machine-token=$TERMINUS_TOKEN
 


### PR DESCRIPTION
Tests are failing in master because of problems in newer Terminus versions. Here's a follow up issue: https://github.com/pantheon-systems/wp-saml-auth/issues/42