### PR TITLE
Only set `GITHUB_TOKEN` when it's present

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -24,8 +24,12 @@ dependencies:
     # Using > instead of >> will overwrite the file and disable xdebug.
     # xdebug makes composer slower.
     - echo "date.timezone = 'US/Central'"  >  /opt/circleci/php/5.6.22/etc/conf.d/xdebug.ini
-    - echo "Setting GitHub OAuth token with suppressed ouput"
     - |
+      if [ -z "$GITHUB_TOKEN" ]; then
+        echo "GITHUB_TOKEN environment variables missing; assuming unauthenticated build"
+        exit 0
+      fi
+      echo "Setting GitHub OAuth token with suppressed ouput"
       {
         composer config -g github-oauth.github.com $GITHUB_TOKEN
       } &> /dev/null


### PR DESCRIPTION
It's not available on all builds.