### PR TITLE
Allows plugin and themes to hook a callback after authentication

### DIFF
--- a/inc/class-wp-saml-auth.php
+++ b/inc/class-wp-saml-auth.php
@@ -140,12 +140,12 @@ class WP_SAML_Auth {
 		$existing_user = get_user_by( $get_user_by, $attributes[ $attribute ][0] );
 		if ( $existing_user ) {
 			/**
-			 * Runs after the user has been authenticated in WordPress
+			 * Runs after a existing user has been authenticated in WordPress
 			 *
-			 * @param int   $user_id    The ID of the user in WordPress
-			 * @param array $attributes All attributes received from the SAML Response
+			 * @param int   $existing_user  The ID user object in WordPress
+			 * @param array $attributes     All attributes received from the SAML Response
 			 */
-			do_action( 'wp_saml_auth_user_authenticated', $existing_user, $attributes );
+			do_action( 'wp_saml_auth_existing_user_authenticated', $existing_user, $attributes );
 
 			return $existing_user;
 		}

--- a/inc/class-wp-saml-auth.php
+++ b/inc/class-wp-saml-auth.php
@@ -142,11 +142,10 @@ class WP_SAML_Auth {
 			/**
 			 * Runs after a existing user has been authenticated in WordPress
 			 *
-			 * @param int   $existing_user  The ID user object in WordPress
-			 * @param array $attributes     All attributes received from the SAML Response
+			 * @param WP_User $existing_user  The existing user object.
+			 * @param array   $attributes     All attributes received from the SAML Response
 			 */
 			do_action( 'wp_saml_auth_existing_user_authenticated', $existing_user, $attributes );
-
 			return $existing_user;
 		}
 		if ( ! self::get_option( 'auto_provision' ) ) {
@@ -165,16 +164,17 @@ class WP_SAML_Auth {
 		if ( is_wp_error( $user_id ) ) {
 			return $user_id;
 		}
+		
+		$user = get_user_by( 'id', $user_id );
 
 		/**
 		 * Runs after the user has been authenticated in WordPress
 		 *
-		 * @param int   $user_id    The ID of the user in WordPress
-		 * @param array $attributes All attributes received from the SAML Response
+		 * @param WP_User $user       The new user object.
+		 * @param array   $attributes All attributes received from the SAML Response
 		 */
-		do_action( 'wp_saml_auth_user_authenticated', $user_id, $attributes );
-
-		return get_user_by( 'id', $user_id );
+		do_action( 'wp_saml_auth_new_user_authenticated', $user, $attributes );
+		return $user;
 	}
 
 }

--- a/inc/class-wp-saml-auth.php
+++ b/inc/class-wp-saml-auth.php
@@ -164,7 +164,7 @@ class WP_SAML_Auth {
 		if ( is_wp_error( $user_id ) ) {
 			return $user_id;
 		}
-		
+
 		$user = get_user_by( 'id', $user_id );
 
 		/**

--- a/inc/class-wp-saml-auth.php
+++ b/inc/class-wp-saml-auth.php
@@ -139,6 +139,14 @@ class WP_SAML_Auth {
 		}
 		$existing_user = get_user_by( $get_user_by, $attributes[ $attribute ][0] );
 		if ( $existing_user ) {
+			/**
+			 * Runs after the user has been authenticated in WordPress
+			 *
+			 * @param int   $user_id    The ID of the user in WordPress
+			 * @param array $attributes All attributes received from the SAML Response
+			 */
+			do_action( 'wp_saml_auth_user_authenticated', $existing_user, $attributes );
+
 			return $existing_user;
 		}
 		if ( ! self::get_option( 'auto_provision' ) ) {
@@ -157,6 +165,15 @@ class WP_SAML_Auth {
 		if ( is_wp_error( $user_id ) ) {
 			return $user_id;
 		}
+
+		/**
+		 * Runs after the user has been authenticated in WordPress
+		 *
+		 * @param int   $user_id    The ID of the user in WordPress
+		 * @param array $attributes All attributes received from the SAML Response
+		 */
+		do_action( 'wp_saml_auth_user_authenticated', $user_id, $attributes );
+
 		return get_user_by( 'id', $user_id );
 	}
 


### PR DESCRIPTION
It can be useful to let plugins and themes hook a callback after the user is authenticated and before returning the user object.

E.g: on a client site I'm working on we're sending additional fields in the SAML Response, and we need to store that as user meta. 