### PR TITLE
Pass `$attributes` to `wp_saml_auth_insert_user` filter

### DIFF
--- a/inc/class-wp-saml-auth.php
+++ b/inc/class-wp-saml-auth.php
@@ -261,7 +261,13 @@ class WP_SAML_Auth {
 		}
 		$user_args['role'] = self::get_option( 'default_role' );
 		$user_args['user_pass'] = wp_generate_password();
-		$user_args = apply_filters( 'wp_saml_auth_insert_user', $user_args );
+		/**
+		 * Runs before a user is created based off a SAML response.
+		 *
+		 * @param array $user_args Arguments passed to wp_insert_user().
+		 * @param array $attributes Attributes from the SAML response.
+		 */
+		$user_args = apply_filters( 'wp_saml_auth_insert_user', $user_args, $attributes );
 		$user_id = wp_insert_user( $user_args );
 		if ( is_wp_error( $user_id ) ) {
 			return $user_id;


### PR DESCRIPTION
This lets the user creation arguments be dynamically adjusted based on
the SAML response.

See #84