### PR TITLE
Update class-wp-saml-auth.php - login url compatibility

### DIFF
--- a/inc/class-wp-saml-auth.php
+++ b/inc/class-wp-saml-auth.php
@@ -228,7 +228,7 @@ class WP_SAML_Auth {
 				}
 				$attributes  = $this->provider->getAttributes();
 				$redirect_to = filter_input( INPUT_POST, 'RelayState', FILTER_SANITIZE_URL );
-				if ( $redirect_to && false === stripos( $redirect_to, parse_url(wp_login_url(), PHP_URL_PATH) ) ) {
+				if ( $redirect_to && false === stripos( $redirect_to, parse_url( wp_login_url(), PHP_URL_PATH ) ) ) {
 					add_filter(
 						'login_redirect', function() use ( $redirect_to ) {
 							return $redirect_to;

--- a/inc/class-wp-saml-auth.php
+++ b/inc/class-wp-saml-auth.php
@@ -228,7 +228,7 @@ class WP_SAML_Auth {
 				}
 				$attributes  = $this->provider->getAttributes();
 				$redirect_to = filter_input( INPUT_POST, 'RelayState', FILTER_SANITIZE_URL );
-				if ( $redirect_to && false === stripos( $redirect_to, 'wp-login.php' ) ) {
+				if ( $redirect_to && false === stripos( $redirect_to, parse_url(wp_login_url(), PHP_URL_PATH) ) ) {
 					add_filter(
 						'login_redirect', function() use ( $redirect_to ) {
 							return $redirect_to;


### PR DESCRIPTION
row 231: 
  substitute 'wp-login.php' string with parse_url(wp_login_url(), PHP_URL_PATH) for compatibility with plugins and functions that alter standard login url
