### PR TITLE
Persist `redirect_to` value in a more accurate manner

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **Tags:** authentication, SAML  
 **Requires at least:** 4.4  
 **Tested up to:** 4.9  
-**Stable tag:** 0.3.6  
+**Stable tag:** 0.3.7  
 **License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html  
 
@@ -252,6 +252,9 @@ Note: the declaration does need to be at the top of `_include.php`, to ensure Wo
 There is no third step. Because SimpleSAMLphp loads WordPress, which has WP Native PHP Sessions active, SimpleSAMLphp and WP SAML Auth will be able to communicate to one another on a multi web node environment.
 
 ## Changelog ##
+
+### 0.3.7 (February 13, 2018) ###
+* Persists `redirect_to` value in a more accurate manner, as a follow up to the change in v0.3.6 [[#113](https://github.com/pantheon-systems/wp-saml-auth/pull/113)].
 
 ### 0.3.6 (February 7, 2018) ###
 * Prevents WordPress from dropping authentication cookie when user is redirected to login from `/wp-admin/` URLs [[#112](https://github.com/pantheon-systems/wp-saml-auth/pull/112)].

--- a/inc/class-wp-saml-auth.php
+++ b/inc/class-wp-saml-auth.php
@@ -241,11 +241,19 @@ class WP_SAML_Auth {
 				$this->provider->login( $redirect_to );
 			}
 		} elseif ( is_a( $this->provider, 'SimpleSAML_Auth_Simple' ) ) {
+			$redirect_to = filter_input( INPUT_GET, 'redirect_to', FILTER_SANITIZE_URL );
+			if ( $redirect_to ) {
+				$redirect_to = add_query_arg( 'redirect_to', $redirect_to, wp_login_url() );
+			} else {
+				$redirect_to = wp_login_url();
+				// Only persist redirect_to when it's not wp-login.php.
+				if ( false === stripos( $redirect_to, $_SERVER['REQUEST_URI'] ) ) {
+					$redirect_to = add_query_arg( 'redirect_to', $_SERVER['REQUEST_URI'], $redirect_to );
+				}
+			}
 			$this->provider->requireAuth(
 				array(
-					// Prevent WordPress from dropping the login cookie
-					// when REQUEST_URI is /wp-admin/.
-					'ReturnTo' => str_replace( '&reauth=1', '', $_SERVER['REQUEST_URI'] ),
+					'ReturnTo' => $redirect_to,
 				)
 			);
 			$attributes = $this->provider->getAttributes();

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: getpantheon, danielbachhuber, Outlandish Josh
 Tags: authentication, SAML
 Requires at least: 4.4
 Tested up to: 4.9
-Stable tag: 0.3.6
+Stable tag: 0.3.7
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -252,6 +252,9 @@ Note: the declaration does need to be at the top of `_include.php`, to ensure Wo
 There is no third step. Because SimpleSAMLphp loads WordPress, which has WP Native PHP Sessions active, SimpleSAMLphp and WP SAML Auth will be able to communicate to one another on a multi web node environment.
 
 == Changelog ==
+
+= 0.3.7 (February 13, 2018) =
+* Persists `redirect_to` value in a more accurate manner, as a follow up to the change in v0.3.6 [[#113](https://github.com/pantheon-systems/wp-saml-auth/pull/113)].
 
 = 0.3.6 (February 7, 2018) =
 * Prevents WordPress from dropping authentication cookie when user is redirected to login from `/wp-admin/` URLs [[#112](https://github.com/pantheon-systems/wp-saml-auth/pull/112)].

--- a/wp-saml-auth.php
+++ b/wp-saml-auth.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: WP SAML Auth
- * Version: 0.3.6
+ * Version: 0.3.7
  * Description: SAML authentication for WordPress, using SimpleSAMLphp.
  * Author: Pantheon
  * Author URI: https://pantheon.io


### PR DESCRIPTION
Pull it out of the URL when present:

```
/wp-login.php?redirect_to=http%3A%2F%2Fwp-saml-auth.dev%2Fwp-admin%2Fplugins.php&reauth=1
```

Otherwise, defer to `$_SERVER['REQUEST_URI']` except when already on
`wp-login.php`

See #111
Previously #112