### PR TITLE
Redirect to `action=wp-saml-auth` when `redirect_to` is persisted

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ matrix:
       env: WP_TRAVISCI=phpcs
 
 before_script:
-  - export PATH="$HOME/.composer/vendor/bin:$PATH"
+  - export PATH="$HOME/.composer/vendor/bin:$HOME/.config/composer/vendor/bin:$PATH"
   - |
     if [[ ! -z "$WP_VERSION" ]] ; then
       bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION
@@ -46,7 +46,7 @@ before_script:
   - |
     if [[ "$WP_TRAVISCI" == "phpcs" ]] ; then
       composer global require wp-coding-standards/wpcs
-      phpcs --config-set installed_paths $HOME/.composer/vendor/wp-coding-standards/wpcs
+      phpcs --config-set installed_paths $HOME/.config/composer/vendor/wp-coding-standards/wpcs
     fi
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ matrix:
       env: WP_TRAVISCI=phpcs
 
 before_script:
-  - export PATH="$HOME/.composer/vendor/bin:$HOME/.config/composer/vendor/bin:$PATH"
+  - export PATH="$HOME/.composer/vendor/bin:$PATH"
   - |
     if [[ ! -z "$WP_VERSION" ]] ; then
       bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION
@@ -46,7 +46,7 @@ before_script:
   - |
     if [[ "$WP_TRAVISCI" == "phpcs" ]] ; then
       composer global require wp-coding-standards/wpcs
-      phpcs --config-set installed_paths $HOME/.config/composer/vendor/wp-coding-standards/wpcs
+      phpcs --config-set installed_paths $HOME/.composer/vendor/wp-coding-standards/wpcs
     fi
 
 script:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **Tags:** authentication, SAML  
 **Requires at least:** 4.4  
 **Tested up to:** 4.9  
-**Stable tag:** 0.3.7  
+**Stable tag:** 0.3.8  
 **License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html  
 
@@ -252,6 +252,9 @@ Note: the declaration does need to be at the top of `_include.php`, to ensure Wo
 There is no third step. Because SimpleSAMLphp loads WordPress, which has WP Native PHP Sessions active, SimpleSAMLphp and WP SAML Auth will be able to communicate to one another on a multi web node environment.
 
 ## Changelog ##
+
+### 0.3.8 (February 26, 2018) ###
+* Redirects to `action=wp-saml-auth` when `redirect_to` is persisted, to ensure authentication is handled [[#115](https://github.com/pantheon-systems/wp-saml-auth/pull/115)].
 
 ### 0.3.7 (February 13, 2018) ###
 * Persists `redirect_to` value in a more accurate manner, as a follow up to the change in v0.3.6 [[#113](https://github.com/pantheon-systems/wp-saml-auth/pull/113)].

--- a/inc/class-wp-saml-auth.php
+++ b/inc/class-wp-saml-auth.php
@@ -243,7 +243,10 @@ class WP_SAML_Auth {
 		} elseif ( is_a( $this->provider, 'SimpleSAML_Auth_Simple' ) ) {
 			$redirect_to = filter_input( INPUT_GET, 'redirect_to', FILTER_SANITIZE_URL );
 			if ( $redirect_to ) {
-				$redirect_to = add_query_arg( 'redirect_to', $redirect_to, wp_login_url() );
+				$redirect_to = add_query_arg( array(
+					'redirect_to' => $redirect_to,
+					'action'      => 'wp-saml-auth',
+				), wp_login_url() );
 			} else {
 				$redirect_to = wp_login_url();
 				// Only persist redirect_to when it's not wp-login.php.

--- a/inc/class-wp-saml-auth.php
+++ b/inc/class-wp-saml-auth.php
@@ -96,7 +96,7 @@ class WP_SAML_Auth {
 				return;
 			}
 			$this->provider = new SimpleSAML_Auth_Simple( self::get_option( 'auth_source' ) );
-		} // End if().
+		}
 		add_action( 'login_head', array( $this, 'action_login_head' ) );
 		add_action( 'login_message', array( $this, 'action_login_message' ) );
 		add_action( 'wp_logout', array( $this, 'action_wp_logout' ) );
@@ -243,10 +243,12 @@ class WP_SAML_Auth {
 		} elseif ( is_a( $this->provider, 'SimpleSAML_Auth_Simple' ) ) {
 			$redirect_to = filter_input( INPUT_GET, 'redirect_to', FILTER_SANITIZE_URL );
 			if ( $redirect_to ) {
-				$redirect_to = add_query_arg( array(
-					'redirect_to' => $redirect_to,
-					'action'      => 'wp-saml-auth',
-				), wp_login_url() );
+				$redirect_to = add_query_arg(
+					array(
+						'redirect_to' => $redirect_to,
+						'action'      => 'wp-saml-auth',
+					), wp_login_url()
+				);
 			} else {
 				$redirect_to = wp_login_url();
 				// Only persist redirect_to when it's not wp-login.php.

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -7,7 +7,7 @@
 	<file>.</file>
 
 	<!-- Show sniff codes in all reports -->
-	<arg value="s"/>
+	<arg value="ps"/>
 
 	<rule ref="WordPress-Core" />
 	<rule ref="WordPress-Docs" />

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: getpantheon, danielbachhuber, Outlandish Josh
 Tags: authentication, SAML
 Requires at least: 4.4
 Tested up to: 4.9
-Stable tag: 0.3.7
+Stable tag: 0.3.8
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -252,6 +252,9 @@ Note: the declaration does need to be at the top of `_include.php`, to ensure Wo
 There is no third step. Because SimpleSAMLphp loads WordPress, which has WP Native PHP Sessions active, SimpleSAMLphp and WP SAML Auth will be able to communicate to one another on a multi web node environment.
 
 == Changelog ==
+
+= 0.3.8 (February 26, 2018) =
+* Redirects to `action=wp-saml-auth` when `redirect_to` is persisted, to ensure authentication is handled [[#115](https://github.com/pantheon-systems/wp-saml-auth/pull/115)].
 
 = 0.3.7 (February 13, 2018) =
 * Persists `redirect_to` value in a more accurate manner, as a follow up to the change in v0.3.6 [[#113](https://github.com/pantheon-systems/wp-saml-auth/pull/113)].

--- a/wp-saml-auth.php
+++ b/wp-saml-auth.php
@@ -154,7 +154,7 @@ function wpsa_filter_option( $value, $option_name ) {
 		 */
 		'default_role'           => get_option( 'default_role' ),
 	);
-	$value = isset( $defaults[ $option_name ] ) ? $defaults[ $option_name ] : $value;
+	$value    = isset( $defaults[ $option_name ] ) ? $defaults[ $option_name ] : $value;
 	return $value;
 }
 add_filter( 'wp_saml_auth_option', 'wpsa_filter_option', 0, 2 );

--- a/wp-saml-auth.php
+++ b/wp-saml-auth.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: WP SAML Auth
- * Version: 0.3.7
+ * Version: 0.3.8
  * Description: SAML authentication for WordPress, using SimpleSAMLphp.
  * Author: Pantheon
  * Author URI: https://pantheon.io


### PR DESCRIPTION
This ensures authentication is handled.

Fixes #114