### PR TITLE
Allow access to instance of WP_SAML_Auth in insert user filter callbacks

### DIFF
--- a/inc/class-wp-saml-auth.php
+++ b/inc/class-wp-saml-auth.php
@@ -311,10 +311,11 @@ class WP_SAML_Auth {
 		/**
 		 * Runs before a user is created based off a SAML response.
 		 *
-		 * @param array $user_args Arguments passed to wp_insert_user().
-		 * @param array $attributes Attributes from the SAML response.
+		 * @param array        $user_args  Arguments passed to wp_insert_user().
+		 * @param array        $attributes Attributes from the SAML response.
+		 * @param WP_SAML_Auth $this       This instance of WP_SAML_Auth.
 		 */
-		$user_args = apply_filters( 'wp_saml_auth_insert_user', $user_args, $attributes );
+		$user_args = apply_filters( 'wp_saml_auth_insert_user', $user_args, $attributes, $this );
 		$user_id   = wp_insert_user( $user_args );
 		if ( is_wp_error( $user_id ) ) {
 			return $user_id;


### PR DESCRIPTION
First off–thanks for this plugin! It's quite useful.

I'd like to propose the following change:

Allows access to the `WP_SAML_Auth` instance in filter callbacks of `wp_saml_auth_insert_user`.
I have a SAML instance that sends over the desired value to use for user login in the `NameID` element value. There's no way to currently use any properties sent back from the provider apart from `$attributes`. It'd be nice to be able to make decisions arbitrarily via the SAML provider instance of `WP_SAML_Auth`.

If that's agreeable, I think may make sense to allow access to the instance in all the appropriate filters, not just the insert one.

As an aside: I realize that since `WP_SAML_Auth` is a Singleton, I could just call `::get_instance()` in my filter callback, but that feels...bad.