### PR TITLE
Fix issue with redirects loosing args

### DIFF
--- a/inc/class-wp-saml-auth.php
+++ b/inc/class-wp-saml-auth.php
@@ -256,7 +256,7 @@ class WP_SAML_Auth {
 			if ( $redirect_to ) {
 				$redirect_to = add_query_arg(
 					array(
-						'redirect_to' => $redirect_to,
+						'redirect_to' => rawurlencode( $redirect_to ),
 						'action'      => 'wp-saml-auth',
 					), wp_login_url()
 				);

--- a/inc/class-wp-saml-auth.php
+++ b/inc/class-wp-saml-auth.php
@@ -135,7 +135,7 @@ class WP_SAML_Auth {
 		display: none;
 	}
 </style>
-<?php
+		<?php
 	}
 
 	/**

--- a/wp-saml-auth.php
+++ b/wp-saml-auth.php
@@ -154,7 +154,7 @@ function wpsa_filter_option( $value, $option_name ) {
 		 */
 		'default_role'           => get_option( 'default_role' ),
 	);
-	$value    = isset( $defaults[ $option_name ] ) ? $defaults[ $option_name ] : $value;
+	$value = isset( $defaults[ $option_name ] ) ? $defaults[ $option_name ] : $value;
 	return $value;
 }
 add_filter( 'wp_saml_auth_option', 'wpsa_filter_option', 0, 2 );


### PR DESCRIPTION
Redirect URL is not encoded in the `redirect_to` arg, and it may loose it's own args which will be applied to the parent URL... also the URL with missing args might become invalid, example:

1. As a logged out user we are entering the page that requires user to be logged in:
`https://mysite.example.com/?p=1234&preview=1&secret=1234`

2. User being redirected to:
`https://mysite.example.com/wp-login.php?redirect_to=https%3A%2F%2Fmysite.example.com%2F%3Fp%3D1234%26preview%3D1%26secret%3D1234`

3. But then the information that is passed to SimpleSAML lib contains already improperly formatted URL, with not encoded `redirect_to` arg:
`https://mysite.example.com/wp-login.php?redirect_to=https://mysite.example.com/?p=1234&preview=1&secret=1234&action=wp-saml-auth`

4. After all, after successful login, user is redirected to:
`https://mysite.example.com/?p=1234`
but should be to:
`https://mysite.example.com/?p=1234&preview=1&secret=1234`