### PR TITLE
Provide an error message explicitly for when attributes are missing

### DIFF
--- a/inc/class-wp-saml-auth.php
+++ b/inc/class-wp-saml-auth.php
@@ -290,6 +290,10 @@ class WP_SAML_Auth {
 			return $pre_auth;
 		}
 
+		if ( empty( $attributes ) ) {
+			return new WP_Error( 'wp_saml_auth_no_attributes', esc_html__( 'No attributes were present in SAML response. Attributes are used to create and fetch users. Please contact your administrator', 'wp-saml-auth' ) );
+		}
+
 		$get_user_by = self::get_option( 'get_user_by' );
 		$attribute   = self::get_option( "user_{$get_user_by}_attribute" );
 		if ( empty( $attributes[ $attribute ][0] ) ) {


### PR DESCRIPTION
The existing error message isn't very helpful when the SAML response is
entirely empty.