### PR TITLE
Update defaults example assertionConsumerService

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Once you have access to a SAML identity provider, you can configure this plugin 
                 'sp'           => array(
                     'entityId' => 'urn:' . parse_url( home_url(), PHP_URL_HOST ),
                     'assertionConsumerService' => array(
-                        'url'  => home_url('/wp-login.php'),
+                        'url'  => wp_login_url(),
                         'binding' => 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST',
                     ),
                 ),

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Once you have access to a SAML identity provider, you can configure this plugin 
                 'sp'           => array(
                     'entityId' => 'urn:' . parse_url( home_url(), PHP_URL_HOST ),
                     'assertionConsumerService' => array(
-                        'url'  => home_url(),
+                        'url'  => home_url('/wp-login.php'),
                         'binding' => 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST',
                     ),
                 ),

--- a/readme.txt
+++ b/readme.txt
@@ -65,7 +65,7 @@ Once you have access to a SAML identity provider, you can configure this plugin 
                 'sp'           => array(
                     'entityId' => 'urn:' . parse_url( home_url(), PHP_URL_HOST ),
                     'assertionConsumerService' => array(
-                        'url'  => home_url(),
+                        'url'  => wp_login_url(),
                         'binding' => 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST',
                     ),
                 ),


### PR DESCRIPTION
Took me a while to figure out why this my IDP wasn't working. Although the notes say to use `wp-login.php` as the `assertionConsumerService` URL, the defaults don't set that.