### PR TITLE
Add filter to allow modify attributes

### DIFF
--- a/inc/class-wp-saml-auth.php
+++ b/inc/class-wp-saml-auth.php
@@ -283,6 +283,13 @@ class WP_SAML_Auth {
 		}
 
 		/**
+		 * Allows to modify attributes before the SAML authentication.
+		 *
+		 * @param array $attributes All attributes received from the SAML response.
+		 */
+		$attributes = apply_filters( 'wp_saml_auth_attributes', $attributes );
+
+		/**
 		 * Runs before the SAML authentication dance proceeds
 		 *
 		 * Can be used to short-circuit the authentication process.

--- a/inc/class-wp-saml-auth.php
+++ b/inc/class-wp-saml-auth.php
@@ -285,9 +285,10 @@ class WP_SAML_Auth {
 		/**
 		 * Allows to modify attributes before the SAML authentication.
 		 *
-		 * @param array $attributes All attributes received from the SAML response.
+		 * @param array  $attributes All attributes received from the SAML response.
+		 * @param object $provider   Provider instance currently in use.
 		 */
-		$attributes = apply_filters( 'wp_saml_auth_attributes', $attributes );
+		$attributes = apply_filters( 'wp_saml_auth_attributes', $attributes, $this->provider );
 
 		/**
 		 * Runs before the SAML authentication dance proceeds


### PR DESCRIPTION
Add filter to allow modify attributes before SAML authentication.

Case:
In our ecosystem there is various type of accounts to handle and each of them contain a bit different values... this new filter, place, is good to hook in and standarize the received responses.

Fixes #135