### PR TITLE
Change PHP keywords to comply with PSR2

### DIFF
--- a/tests/phpunit/class-simplesaml-auth-simple.php
+++ b/tests/phpunit/class-simplesaml-auth-simple.php
@@ -97,7 +97,7 @@ class SimpleSAML_Auth_Simple {
 	 *                                   or an array with parameters for the logout. If this parameter is
 	 *                                   NULL, we will return to the current page.
 	 */
-	public function logout( $params = NULL ) {
+	public function logout( $params = null ) {
 		$GLOBALS['wp_saml_auth_current_user'] = false;
 	}
 


### PR DESCRIPTION
Hi, I've changed a PHP keyword to comply with [this standard](https://www.php-fig.org/psr/psr-2/#25-keywords-and-truefalsenull) in PSR2. It's admittedly a small fix but I hope it helps!