### PR TITLE
Disable SAML RequestedAuthnContext

### DIFF
--- a/inc/class-wp-saml-auth-options.php
+++ b/inc/class-wp-saml-auth-options.php
@@ -96,17 +96,17 @@ class WP_SAML_Auth_Options {
 		$settings = array(
 			'connection_type' => 'internal',
 			'internal_config' => array(
-				'strict'  => true,
-				'debug'   => defined( 'WP_DEBUG' ) && WP_DEBUG ? true : false,
-				'baseurl' => $options['baseurl'],
-				'sp'      => array(
+				'strict'   => true,
+				'debug'    => defined( 'WP_DEBUG' ) && WP_DEBUG ? true : false,
+				'baseurl'  => $options['baseurl'],
+				'sp'       => array(
 					'entityId'                 => $options['sp_entityId'],
 					'assertionConsumerService' => array(
 						'url'     => $options['sp_assertionConsumerService_url'],
 						'binding' => 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST',
 					),
 				),
-				'idp'     => array(
+				'idp'      => array(
 					'entityId'                 => $options['idp_entityId'],
 					'singleSignOnService'      => array(
 						'url'     => $options['idp_singleSignOnService_url'],
@@ -120,7 +120,7 @@ class WP_SAML_Auth_Options {
 					'certFingerprint'          => $options['certFingerprint'],
 					'certFingerprintAlgorithm' => $options['certFingerprintAlgorithm'],
 				),
-				'security' => array (
+				'security' => array(
 					'requestedAuthnContext' => false,
 				),
 			),

--- a/inc/class-wp-saml-auth-options.php
+++ b/inc/class-wp-saml-auth-options.php
@@ -120,6 +120,9 @@ class WP_SAML_Auth_Options {
 					'certFingerprint'          => $options['certFingerprint'],
 					'certFingerprintAlgorithm' => $options['certFingerprintAlgorithm'],
 				),
+				'security' => array (
+					'requestedAuthnContext' => false,
+				),
 			),
 		);
 


### PR DESCRIPTION
By default, the bundled SAML library, onelogin/php-saml, will set RequestedAuthnContext to PasswordProtectedTransport in the SAML request which does not work with many SAML use cases.  In my case, Windows 10 computers using Azure AD were trying to X509 MultiFactor and were unable to authenticate using this plugin via SAML, getting errors such as "AADSTS75011: Authentication method 'X509, MultiFactor' by which the user authenticated with the service doesn't match requested authentication method 'Password, ProtectedTransport'."

Setting RequestedAuthnContext seemed overly restrictive, so I checked around and could not find other mainstream SAML applications requiring defined RequestedAuthnContext.  I also found https://github.com/onelogin/php-saml/issues/62 where this same issue was being described and as a result the default setting was modified to disable setting RequestedAuthnContext in the SAML request in the latest release of the library; however, this plugin uses its own settings and not the default settings from the library so the plugin reverts to using the overly restrictive setting.  

I have updated the settings in the PR to disable RequestedAuthnContext and broaden compatibility.


