### PR TITLE
Update class-wp-saml-auth-settings.php

### DIFF
--- a/inc/class-wp-saml-auth-settings.php
+++ b/inc/class-wp-saml-auth-settings.php
@@ -286,7 +286,7 @@ class WP_SAML_Auth_Settings {
 	public static function setup_sections() {
 		self::$sections = array(
 			'general'    => '',
-			'sp'         => __( 'Service Provder Settings', 'wp-saml-auth' ),
+			'sp'         => __( 'Service Provider Settings', 'wp-saml-auth' ),
 			'idp'        => __( 'Identity Provider Settings', 'wp-saml-auth' ),
 			'attributes' => __( 'Attribute Mappings', 'wp-saml-auth' ),
 		);


### PR DESCRIPTION
Fixing a typo, added 'i' to 'Provder' so it becomes 'Provider' on line 289 