### PR TITLE
Fix issue where an empty required field would throw load Exception

### DIFF
--- a/inc/class-wp-saml-auth-options.php
+++ b/inc/class-wp-saml-auth-options.php
@@ -37,8 +37,7 @@ class WP_SAML_Auth_Options {
 		if ( self::has_settings_filter() ) {
 			return;
 		}
-		$options = get_option( self::get_option_name() );
-		if ( ! empty( $options['baseurl'] ) ) {
+		if ( self::do_required_settings_have_values() ) {
 			add_filter(
 				'wp_saml_auth_option',
 				array( self::$instance, 'filter_option' ),
@@ -78,6 +77,31 @@ class WP_SAML_Auth_Options {
 			);
 		}
 		return $has_filter;
+	}
+
+	/**
+	 * Whether or not all required settings have non-empty values.
+	 *
+	 * @return boolean
+	 */
+	public function do_required_settings_have_values() {
+		$options = get_option( self::get_option_name() );
+		$retval  = null;
+		foreach ( WP_SAML_Auth_Settings::get_fields() as $field ) {
+			if ( empty( $field['required'] ) ) {
+				continue;
+			}
+			// Required option is empty.
+			if ( empty( $options[ $field['uid'] ] ) ) {
+				$retval = false;
+				continue;
+			}
+			// Required option is present and return value hasn't been set.
+			if ( is_null( $retval ) ) {
+				$retval = true;
+			}
+		}
+		return ! is_null( $retval ) ? $retval : false;
 	}
 
 	/**

--- a/inc/class-wp-saml-auth-settings.php
+++ b/inc/class-wp-saml-auth-settings.php
@@ -158,6 +158,11 @@ class WP_SAML_Auth_Settings {
 				echo sprintf( __( 'Use the following settings to configure WP SAML Auth with the \'internal\' connection type. <a href="%s">Visit the plugin page</a> for more information.', 'wp-saml-auth' ), 'https://wordpress.org/plugins/wp-saml-auth/' );
 				?>
 				</p>
+				<?php if ( WP_SAML_Auth_Options::do_required_settings_have_values() ) : ?>
+					<div class="notice notice-success"><p><?php esc_html_e( 'Settings are actively applied to WP SAML Auth configuration.', 'wp-saml-auth' ); ?></p></div>
+				<?php else : ?>
+					<div class="notice error"><p><?php esc_html_e( 'Some required settings don\'t have values, so WP SAML Auth isn\'t active.', 'wp-saml-auth' ); ?></p></div>
+				<?php endif; ?>
 				<form method="post" action="options.php">
 					<?php
 						settings_fields( self::$option_group );
@@ -341,7 +346,7 @@ class WP_SAML_Auth_Settings {
 			array(
 				'section'     => 'sp',
 				'uid'         => 'sp_entityId',
-				'label'       => __( 'Entity Id', 'wp-saml-auth' ),
+				'label'       => __( 'Entity Id (Required)', 'wp-saml-auth' ),
 				'type'        => 'text',
 				'choices'     => false,
 				'description' => __( 'SP (WordPress) entity identifier.', 'wp-saml-auth' ),
@@ -351,7 +356,7 @@ class WP_SAML_Auth_Settings {
 			array(
 				'section'     => 'sp',
 				'uid'         => 'sp_assertionConsumerService_url',
-				'label'       => __( 'Assertion Consumer Service URL', 'wp-saml-auth' ),
+				'label'       => __( 'Assertion Consumer Service URL (Required)', 'wp-saml-auth' ),
 				'type'        => 'url',
 				'description' => __( 'URL where the response from the IdP should be returned (usually the login URL).', 'wp-saml-auth' ),
 				'default'     => home_url( '/wp-login.php' ),
@@ -361,7 +366,7 @@ class WP_SAML_Auth_Settings {
 			array(
 				'section'     => 'idp',
 				'uid'         => 'idp_entityId',
-				'label'       => __( 'Entity Id', 'wp-saml-auth' ),
+				'label'       => __( 'Entity Id (Required)', 'wp-saml-auth' ),
 				'type'        => 'text',
 				'description' => __( 'IdP entity identifier.', 'wp-saml-auth' ),
 				'required'    => true,
@@ -369,7 +374,7 @@ class WP_SAML_Auth_Settings {
 			array(
 				'section'     => 'idp',
 				'uid'         => 'idp_singleSignOnService_url',
-				'label'       => __( 'Single SignOn Service URL', 'wp-saml-auth' ),
+				'label'       => __( 'Single SignOn Service URL (Required)', 'wp-saml-auth' ),
 				'type'        => 'url',
 				'description' => __( 'URL of the IdP where the SP (WordPress) will send the authentication request.', 'wp-saml-auth' ),
 				'required'    => true,
@@ -445,5 +450,15 @@ class WP_SAML_Auth_Settings {
 				'default' => 'last_name',
 			),
 		);
+	}
+
+	/**
+	 * Gets all of the fields.
+	 *
+	 * @return array
+	 */
+	public static function get_fields() {
+		self::init_fields();
+		return self::$fields;
 	}
 }

--- a/wp-saml-auth.php
+++ b/wp-saml-auth.php
@@ -179,8 +179,8 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 /**
  * Initialize the WP SAML Auth plugin settings page.
  */
+require_once dirname( __FILE__ ) . '/inc/class-wp-saml-auth-settings.php';
 if ( is_admin() ) {
-	require_once dirname( __FILE__ ) . '/inc/class-wp-saml-auth-settings.php';
 	WP_SAML_Auth_Settings::get_instance();
 }
 


### PR DESCRIPTION
If a field like `sp_entityId` were left empty, which the settings form
allows, then WP SAML Auth would throw an Exception when loading:

```
Fatal error: Uncaught OneLogin\Saml2\Error: Invalid array settings: idp_entityId_not_found, idp_sso_not_found
```

The plugin now only applies the settings when all of the required fields are present, and displays a warning message when some required fields are missing:

<img width="854" alt="image" src="https://user-images.githubusercontent.com/36432/67858243-05471280-fad6-11e9-9c2e-53fbd124d0ff.png">


From https://wordpress.org/support/topic/cant-get-in-to-wordpress/