### PR TITLE
load require simpleSAMLphp autoloader only if user is logged in or on…

### DIFF
--- a/inc/class-wp-saml-auth.php
+++ b/inc/class-wp-saml-auth.php
@@ -91,7 +91,9 @@ class WP_SAML_Auth {
 		} else {
 			$simplesamlphp_path = self::get_option( 'simplesamlphp_autoload' );
 			if ( file_exists( $simplesamlphp_path ) ) {
-				require_once $simplesamlphp_path;
+				if ( $GLOBALS['pagenow'] === 'wp-login.php' || is_user_logged_in( ) ) {
+                    require_once $simplesamlphp_path;
+                }
 			}
 			if ( class_exists( 'SimpleSAML\Auth\Simple' ) ) {
 				$this->simplesamlphp_class = 'SimpleSAML\Auth\Simple';


### PR DESCRIPTION
… wp-login page

When simpleSAMLphp is setup using the [Shibboleth pantheon article](https://pantheon.io/docs/shibboleth-sso) we found simpleSAML was creating a cookie for anonymous users.  This caused caching to be ignored for everyone.  That cookie is [mentioned here](https://pantheon.io/docs/caching-advanced-topics) as one that busts the cache.
This mimics the behavior seen in the troubleshooting bit "Varnish Not Working/Cookie Being Set for Anonymous Users" at the bottom of the [Shibboleth pantheon article](https://pantheon.io/docs/shibboleth-sso) 