### PR TITLE
Only add SAML button and explanations on login action

### DIFF
--- a/inc/class-wp-saml-auth.php
+++ b/inc/class-wp-saml-auth.php
@@ -115,6 +115,10 @@ class WP_SAML_Auth {
 	 * Render CSS on the login screen
 	 */
 	public function action_login_head() {
+		if ( ! did_action( 'login_form_login') ) {
+			return;
+		}
+
 		?>
 <style>
 	#wp-saml-auth-cta {
@@ -140,7 +144,7 @@ class WP_SAML_Auth {
 	 * @return string
 	 */
 	public function action_login_message( $message ) {
-		if ( ! self::get_option( 'permit_wp_login' ) ) {
+		if ( ! self::get_option( 'permit_wp_login' ) || ! did_action( 'login_form_login') ) {
 			return $message;
 		}
 		$strings = array(


### PR DESCRIPTION
Hi,

I've noticed the extra HTML the plugin injects into the `wp-login.php` page to explain how to login with SAML or with WordPress is output no matter what the login action. For instance, when you want to get the link to reset your password, here's how the `wp-login.php` page looks:

![lostpassword](https://user-images.githubusercontent.com/1834524/115993310-83ed1500-a5d2-11eb-9641-bf7c24642f02.png)

I believe it's a bit confusing, because if I arrive there, it's because i want to connect with WordPress but I lost my password. So the extra HTML shouldn't be output. I haven't tested other login actions but I believe the same extra HTML would be output.

This PR suggests to check if the `login_form_login` action happened before injecting this extra HTML.

