### PR TITLE
Allow the internal logout args to be filterable

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **Tags:** authentication, SAML  
 **Requires at least:** 4.4  
 **Tested up to:** 5.8  
-**Stable tag:** 1.2.3  
+**Stable tag:** 1.2.4  
 **License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html  
 
@@ -276,6 +276,9 @@ Note: the declaration does need to be at the top of `_include.php`, to ensure Wo
 There is no third step. Because SimpleSAMLphp loads WordPress, which has WP Native PHP Sessions active, SimpleSAMLphp and WP SAML Auth will be able to communicate to one another on a multi web node environment.
 
 ## Changelog ##
+
+### 1.2.4 (August 18, 2021) ###
+* Adds a `wp_saml_auth_internal_logout_args` filter to allow the internal logout args to be filterable [[#255](https://github.com/pantheon-systems/wp-saml-auth/pull/255)].
 
 ### 1.2.3 (May 25, 2021) ###
 * Adds a `wp_saml_auth_force_authn` filter to allow forceAuthn="true" to be enabled [[#248](https://github.com/pantheon-systems/wp-saml-auth/pull/248)].

--- a/inc/class-wp-saml-auth.php
+++ b/inc/class-wp-saml-auth.php
@@ -183,8 +183,26 @@ class WP_SAML_Auth {
 			if ( empty( $internal_config['idp']['singleLogoutService']['url'] ) ) {
 				return;
 			}
+			$args = array(
+				'parameters' => array(),
+				'nameId'     => null,
+				'sessionId'  => null,
+			);
+			/**
+			 * Permit the arguments passed to the logout() method to be customized.
+			 *
+			 * @param array $args Existing arguments to be passed.
+			 */
+			$args = apply_filters( 'wp_saml_auth_internal_logout_args', $args );
+			$provider->logout(
+				add_query_arg( 'loggedout', true, wp_login_url() ),
+				$args['parameters'],
+				$args['nameId'],
+				$args['sessionIndex']
+			);
+		} else {
+			$provider->logout( add_query_arg( 'loggedout', true, wp_login_url() ) );
 		}
-		$provider->logout( add_query_arg( 'loggedout', true, wp_login_url() ) );
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: getpantheon, danielbachhuber, Outlandish Josh
 Tags: authentication, SAML
 Requires at least: 4.4
 Tested up to: 5.8
-Stable tag: 1.2.3
+Stable tag: 1.2.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -276,6 +276,9 @@ Note: the declaration does need to be at the top of `_include.php`, to ensure Wo
 There is no third step. Because SimpleSAMLphp loads WordPress, which has WP Native PHP Sessions active, SimpleSAMLphp and WP SAML Auth will be able to communicate to one another on a multi web node environment.
 
 == Changelog ==
+
+= 1.2.4 (August 18, 2021) =
+* Adds a `wp_saml_auth_internal_logout_args` filter to allow the internal logout args to be filterable [[#255](https://github.com/pantheon-systems/wp-saml-auth/pull/255)].
 
 = 1.2.3 (May 25, 2021) =
 * Adds a `wp_saml_auth_force_authn` filter to allow forceAuthn="true" to be enabled [[#248](https://github.com/pantheon-systems/wp-saml-auth/pull/248)].

--- a/wp-saml-auth.php
+++ b/wp-saml-auth.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: WP SAML Auth
- * Version: 1.2.3
+ * Version: 1.2.4
  * Description: SAML authentication for WordPress, using SimpleSAMLphp.
  * Author: Pantheon
  * Author URI: https://pantheon.io


### PR DESCRIPTION
See https://wordpress.org/support/topic/when-logging-out-the-sessionindex-and-nameid-is-not-passed-to-the-idp/