### PR TITLE
Adding custom user field handling

### DIFF
--- a/inc/class-wp-saml-auth-settings.php
+++ b/inc/class-wp-saml-auth-settings.php
@@ -454,7 +454,7 @@ class WP_SAML_Auth_Settings {
 			array_push(self::$fields, array(
 				'section' => 'attributes',
 				'uid'     => $attr.'_attribute',
-				'label'   => $label,
+				'label'   => $attr,
 				'type'    => 'text',
 				'default' => '',
 			));

--- a/inc/class-wp-saml-auth-settings.php
+++ b/inc/class-wp-saml-auth-settings.php
@@ -449,6 +449,16 @@ class WP_SAML_Auth_Settings {
 				'default' => 'last_name',
 			),
 		);
+		$custom_attributes = wp_get_user_contact_methods();
+		foreach($custom_attributes as $attr => $label) {
+			array_push(self::$fields, array(
+				'section' => 'attributes',
+				'uid'     => $attr.'_attribute',
+				'label'   => $label,
+				'type'    => 'text',
+				'default' => '',
+			));
+		}
 	}
 
 	/**

--- a/inc/class-wp-saml-auth.php
+++ b/inc/class-wp-saml-auth.php
@@ -363,7 +363,8 @@ class WP_SAML_Auth {
 		}
 
 		$user_args = array();
-		foreach ( array( 'display_name', 'user_login', 'user_email', 'first_name', 'last_name' ) as $type ) {
+		$attributeTypes = explode(',', self::get_option( "attributeTypes" ));
+		foreach ( $attributeTypes as $type ) {
 			$attribute          = self::get_option( "{$type}_attribute" );
 			$user_args[ $type ] = ! empty( $attributes[ $attribute ][0] ) ? $attributes[ $attribute ][0] : '';
 		}

--- a/inc/class-wp-saml-auth.php
+++ b/inc/class-wp-saml-auth.php
@@ -363,7 +363,11 @@ class WP_SAML_Auth {
 		}
 
 		$user_args = array();
-		$attributeTypes = explode(',', self::get_option( "attributeTypes" ));
+		$attributeTypes = array( 'display_name', 'user_login', 'user_email', 'first_name', 'last_name' );
+		$custom_attributes = wp_get_user_contact_methods();
+		foreach($custom_attributes as $attr => $label) {
+			array_push($attributeTypes, $attr);
+		}
 		foreach ( $attributeTypes as $type ) {
 			$attribute          = self::get_option( "{$type}_attribute" );
 			$user_args[ $type ] = ! empty( $attributes[ $attribute ][0] ) ? $attributes[ $attribute ][0] : '';

--- a/wp-saml-auth.php
+++ b/wp-saml-auth.php
@@ -154,6 +154,11 @@ function wpsa_filter_option( $value, $option_name ) {
 		 */
 		'default_role'           => get_option( 'default_role' ),
 	);
+	$custom_attributes = wp_get_user_contact_methods();
+	foreach($custom_attributes as $attr => $label) {
+		$defaults[$attr.'_attribute'] = $attr;
+	}
+
 	$value = isset( $defaults[ $option_name ] ) ? $defaults[ $option_name ] : $value;
 	return $value;
 }


### PR DESCRIPTION
We have some extra data in our user accounts that would be useful to have in WP, so I've added a basic inclusion of WP custom user fields as defined with the user_contactmethods filter. To use it in response to the 'wp_saml_auth_*_user_authenticated' actions I have:

```
	$attributeTypes = array( 'display_name', 'first_name', 'last_name', 'user_email');
	$custom_attributes = wp_get_user_contact_methods();
	foreach($custom_attributes as $attr => $label) {
		array_push($attributeTypes, $attr);
	}
	foreach ( $attributeTypes as $type ) {
		...
```

it is working for us, but please let me know if I can clean anything up