### PR TITLE
update build-tag to use an alternate source for version number

### DIFF
--- a/.github/workflows/build-tag.yml
+++ b/.github/workflows/build-tag.yml
@@ -16,11 +16,15 @@ jobs:
       run: |
         composer install --no-dev -o
     - name: Setup
-      run: 'echo "VERSION=$(jq -r .version ./package.json)" >> $GITHUB_ENV'
+      run: |
+        VERSION=$(cat readme.txt| grep 'Stable tag:' | awk '{print $3}')
+        [[ "$VERSION" != "" ]] || exit 1
+        echo "VERSION=$VERSION" >> $GITHUB_ENV
 
     - name: Tag
       run: |
         echo "Releasing version $VERSION ..."
+        [[ "$VERSION" != "" ]] || exit 1
         git config user.name Pantheon Automation
         git config user.email bot@getpantheon.com
         git checkout -b "release-$VERSION"


### PR DESCRIPTION
Merging of #335 did not tag correctly, and the tag for https://github.com/pantheon-systems/wp-saml-auth/releases/tag/2.1.2 is missing the vendor directory, breaking on install/update.

This grabs the version number from README instead. tested with a one-off (now squashed) workflow here: https://github.com/pantheon-systems/wp-saml-auth/actions/runs/4648184638/jobs/8225707970