### PR TITLE
Release 2.1.3

### DIFF
--- a/.github/workflows/build-tag.yml
+++ b/.github/workflows/build-tag.yml
@@ -16,11 +16,15 @@ jobs:
       run: |
         composer install --no-dev -o
     - name: Setup
-      run: 'echo "VERSION=$(jq -r .version ./package.json)" >> $GITHUB_ENV'
+      run: |
+        VERSION=$(cat readme.txt| grep 'Stable tag:' | awk '{print $3}')
+        [[ "$VERSION" != "" ]] || exit 1
+        echo "VERSION=$VERSION" >> $GITHUB_ENV
 
     - name: Tag
       run: |
         echo "Releasing version $VERSION ..."
+        [[ "$VERSION" != "" ]] || exit 1
         git config user.name Pantheon Automation
         git config user.email bot@getpantheon.com
         git checkout -b "release-$VERSION"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 **Requires at least:** 4.4  
 **Tested up to:** 6.2  
 **Requires PHP:** 7.3  
-**Stable tag:** 2.1.2  
+**Stable tag:** 2.1.3  
 **License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html  
 
@@ -272,6 +272,9 @@ There is no third step. Because SimpleSAMLphp loads WordPress, which has WP Nati
 Minimum supported PHP version is 7.3.
 
 ## Changelog ##
+
+## 2.1.3 (April 8, 2023) ##
+* Fixes missing vendor/ directory in previous release [[#336](https://github.com/pantheon-systems/wp-saml-auth/pull/336)]
 
 ## 2.1.2 (April 7, 2023) ##
 * Bump yoast/phpunit-polyfills from 1.0.4 to 1.0.5 [[#334](https://github.com/pantheon-systems/wp-saml-auth/pull/334)]

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: authentication, SAML
 Requires at least: 4.4
 Tested up to: 6.2
 Requires PHP: 7.3
-Stable tag: 2.1.2
+Stable tag: 2.1.3
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -272,6 +272,9 @@ There is no third step. Because SimpleSAMLphp loads WordPress, which has WP Nati
 Minimum supported PHP version is 7.3.
 
 == Changelog ==
+
+= 2.1.3 (April 8, 2023) =
+* Fixes missing vendor/ directory in previous release [[#336](https://github.com/pantheon-systems/wp-saml-auth/pull/336)]
 
 = 2.1.2 (April 7, 2023) =
 * Bump yoast/phpunit-polyfills from 1.0.4 to 1.0.5 [[#334](https://github.com/pantheon-systems/wp-saml-auth/pull/334)]

--- a/wp-saml-auth.php
+++ b/wp-saml-auth.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: WP SAML Auth
- * Version: 2.1.2
+ * Version: 2.1.3
  * Description: SAML authentication for WordPress, using SimpleSAMLphp.
  * Author: Pantheon
  * Author URI: https://pantheon.io


### PR DESCRIPTION
Cutting a new release that will tag with the vendor/ directory

- update build-tag to use an alternate source for version number (#336)