### PR TITLE
handle hidden character in version number

### DIFF
--- a/.github/workflows/build-tag.yml
+++ b/.github/workflows/build-tag.yml
@@ -17,7 +17,7 @@ jobs:
         composer install --no-dev -o
     - name: Setup
       run: |
-        VERSION=$(cat readme.txt| grep 'Stable tag:' | awk '{print $3}')
+        VERSION=$(cat README.md| grep 'Stable tag:' | awk '{print $3}')
         [[ "$VERSION" != "" ]] || exit 1
         echo "VERSION=$VERSION" >> $GITHUB_ENV
 


### PR DESCRIPTION
Follows #337  and #336—
Hidden character in readme.txt was making its way into the git commands and breaking workflow. Use .md instead.