### PR TITLE
Re-sync clean-up of development branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ jobs:
   lint:
     working_directory: ~/pantheon-systems/wp-saml-auth
     docker:
-      - image: quay.io/pantheon-public/build-tools-ci:8.x-php8.2
+      - image: quay.io/pantheon-public/build-tools-ci:8.x-php8.0
     steps:
       - checkout
       - restore_cache:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,12 +25,24 @@ Behat requires a Pantheon site. Once you've created the site, you'll need [insta
 
 ## Release Process
 
-1. Starting from `develop`, cut a release branch named `release_X.Y.Z` containing your changes.
-1. Update plugin version in `package.json`, `README.md`, `readme.txt`, and `wp-saml-auth.php`.
-1. Update the Changelog with the latest changes.
-1. Create a PR against the `master` branch.
-1. After all tests pass and you have received approval from a CODEOWNER (including resolving any merge conflicts), merge the PR into `master`.
-1. [Check the _Build and Tag_ action](https://github.com/pantheon-systems/wp-saml-auth/actions/workflows/build-tag.yml): a new tag named with the version number should've been created. It should contain all the built assets.
-1. Create a [new release](https://github.com/pantheon-systems/wp-saml-auth/releases/new), naming the release with the new version number, and targeting the tag created in the previous step. Paste the release changelog from the `Changelog` section of the `README` into the body of the release and include a link to the closed issues if applicable.
-1. Wait for the [_Release wp-saml-auth plugin to wp.org_ action](https://github.com/pantheon-systems/wp-saml-auth/actions/workflows/wordpress-plugin-deploy.yml) to finish deploying to the WordPress.org repository. If all goes well, users with SVN commit access for that plugin will receive an emailed diff of changes.
-1. Check WordPress.org: Ensure that the changes are live on https://wordpress.org/plugins/wp-saml-auth/. This may take a few minutes.
+1. From `develop`, checkout a new branch `release_X.Y.Z`.
+1. Make a release commit:
+    * Drop the `-dev` from the version number in `README.md`, `readme.txt`, and `wp-saml-auth.php`.
+    * Update the "Latest" heading in the changelog to the new version number with the date
+    * Commit these changes with the message `Release X.Y.Z`
+    * Push the release branch up.
+1. Open a Pull Request to merge `release_X.Y.Z` into `main`. Your PR should consist of all commits to `develop` since the last release, and one commit to update the version number. The PR name should also be `Release X.Y.Z`.
+1. After all tests pass and you have received approval from a [CODEOWNER](./CODEOWNERS), merge the PR into `master`. "Rebase and merge" is preferred in this case. _Never_ squash to `master`.
+1. Pull `master` locally, create a new tag (based on version number from previous steps), and push up. The tag should _only_ be the version number. It _should not_ be prefixed  `v` (i.e. `X.Y.Z`, not `vX.Y.X`).
+1. Confirm that the necessary assets are present in the newly created tag, and test on a WP install if desired.
+1. Create a [new release](https://github.com/pantheon-systems/wp-saml-auth/releases/new) using the tag created in the previous steps, naming the release with the new version number, and targeting the tag created in the previous step. Paste the release changelog from the `Changelog` section of [the readme](readme.txt) into the body of the release, including the links to the closed issues if applicable.
+1. Wait for the [_Release wp-saml-auth plugin to wp.org_ action](https://github.com/pantheon-systems/wp-saml-auth/actions/workflows/wordpress-plugin-deploy.yml) to finish deploying to the WordPress.org plugin repository. If all goes well, users with SVN commit access for that plugin will receive an emailed diff of changes.
+1. Check WordPress.org: Ensure that the changes are live on [the plugin repository](https://wordpress.org/plugins/wp-saml-auth/). This may take a few minutes.
+1. Following the release, prepare the next dev version with the following steps:
+    * `git checkout develop`
+    * `git rebase master`
+    * Update the version number in all locations, incrementing the version by one patch version, and add the `-dev` flag (e.g. after releasing `1.2.3`, the new verison will be `1.2.4-dev`)
+    * Add a new `** Latest **` heading to the changelog
+    * `git add -A .`
+    * `git commit -m "Prepare X.Y.X-dev"`
+    * `git push origin develop`

--- a/README.md
+++ b/README.md
@@ -274,7 +274,8 @@ Minimum supported PHP version is 7.3.
 ## Changelog ##
 
 ### Latest ###
-* Updates CONTRIBUTING.md [[#342](https://github.com/pantheon-systems/wp-saml-auth/pull/342)]
+* Updates CONTRIBUTING.md [[#342](https://github.com/pantheon-systems/wp-saml-auth/pull/342)].
+* Bump dependencies [[#343](https://github.com/pantheon-systems/wp-saml-auth/pull/343)]
 
 ### 2.1.3 (April 8, 2023) ###
 * Fixes missing vendor/ directory in previous release [[#336](https://github.com/pantheon-systems/wp-saml-auth/pull/336)]

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 **Requires at least:** 4.4  
 **Tested up to:** 6.2  
 **Requires PHP:** 7.3  
-**Stable tag:** 2.1.3  
+**Stable tag:** 2.1.4-dev  
 **License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html  
 
@@ -273,21 +273,23 @@ Minimum supported PHP version is 7.3.
 
 ## Changelog ##
 
-## 2.1.3 (April 8, 2023) ##
+### Latest ###
+* Updates CONTRIBUTING.md [[#342](https://github.com/pantheon-systems/wp-saml-auth/pull/342)]
+
+### 2.1.3 (April 8, 2023) ###
 * Fixes missing vendor/ directory in previous release [[#336](https://github.com/pantheon-systems/wp-saml-auth/pull/336)]
 
-## 2.1.2 (April 7, 2023) ##
+### 2.1.2 (April 7, 2023) ###
 * Bump yoast/phpunit-polyfills from 1.0.4 to 1.0.5 [[#334](https://github.com/pantheon-systems/wp-saml-auth/pull/334)]
 * Updates tested up to version
 * Removes unused NPM dependencies 
 
-
-## 2.1.1 (March 15, 2023) ##
+### 2.1.1 (March 15, 2023) ###
 * Adds PHP 8.2 compatibility [[#332](https://github.com/pantheon-systems/wp-saml-auth/pull/332)].
 * Make dependabot target develop branch [[#313](https://github.com/pantheon-systems/wp-saml-auth/pull/313)].
 * Bump dependencies [[#308](https://github.com/pantheon-systems/wp-saml-auth/pull/308)] [[#310](https://github.com/pantheon-systems/wp-saml-auth/pull/310)] [[#314](https://github.com/pantheon-systems/wp-saml-auth/pull/314)] [[#319](https://github.com/pantheon-systems/wp-saml-auth/pull/319)] [[#322](https://github.com/pantheon-systems/wp-saml-auth/pull/322)] [[#323](https://github.com/pantheon-systems/wp-saml-auth/pull/323)] [[#324](https://github.com/pantheon-systems/wp-saml-auth/pull/324)] [[#325](https://github.com/pantheon-systems/wp-saml-auth/pull/325)] [[#326](https://github.com/pantheon-systems/wp-saml-auth/pull/326)] [[#330](https://github.com/pantheon-systems/wp-saml-auth/pull/330)].
 
-## 2.1.0 (November 29, 2022) ##
+### 2.1.0 (November 29, 2022) ###
 * Adds Github Actions for building tag and deploying to wp.org. Add CONTRIBUTING.md. [[#311](https://github.com/pantheon-systems/wp-saml-auth/pull/311)]
 
 ### 2.0.1 (January 24, 2022) ###

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "symfony/filesystem": "^5",
         "symfony/service-contracts": "^2",
         "symfony/translation-contracts": "^2",
-        "yoast/phpunit-polyfills": "^1.0"
+        "yoast/phpunit-polyfills": "^2.0"
     },
     "scripts": {
         "lint": "@phpcs",

--- a/composer.json
+++ b/composer.json
@@ -21,10 +21,8 @@
     },
     "require-dev": {
         "pantheon-systems/pantheon-wordpress-upstream-tests": "dev-master",
-        "wp-coding-standards/wpcs": "dev-develop as 2.3.1",
-        "dealerdirect/phpcodesniffer-composer-installer": "^1.0.0",
+        "pantheon-systems/pantheon-wp-coding-standards": "^1.0",
         "phpunit/phpunit": "^9",
-        "phpcompatibility/php-compatibility": "^9.3",
         "symfony/filesystem": "^5",
         "symfony/service-contracts": "^2",
         "symfony/translation-contracts": "^2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "21f95f38a7b49478f1b8f1f018a744c6",
+    "content-hash": "773059593163b7454eeac937771b7b2d",
     "packages": [
         {
             "name": "onelogin/php-saml",
@@ -106,6 +106,58 @@
         }
     ],
     "packages-dev": [
+        {
+            "name": "automattic/vipwpcs",
+            "version": "2.3.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Automattic/VIP-Coding-Standards.git",
+                "reference": "6cd0a6a82bc0ac988dbf9d6a7c2e293dc8ac640b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Automattic/VIP-Coding-Standards/zipball/6cd0a6a82bc0ac988dbf9d6a7c2e293dc8ac640b",
+                "reference": "6cd0a6a82bc0ac988dbf9d6a7c2e293dc8ac640b",
+                "shasum": ""
+            },
+            "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7",
+                "php": ">=5.4",
+                "sirbrillig/phpcs-variable-analysis": "^2.11.1",
+                "squizlabs/php_codesniffer": "^3.5.5",
+                "wp-coding-standards/wpcs": "^2.3"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-console-highlighter": "^0.5",
+                "php-parallel-lint/php-parallel-lint": "^1.0",
+                "phpcompatibility/php-compatibility": "^9",
+                "phpcsstandards/phpcsdevtools": "^1.0",
+                "phpunit/phpunit": "^4 || ^5 || ^6 || ^7"
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/Automattic/VIP-Coding-Standards/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer rules (sniffs) to enforce WordPress VIP minimum coding conventions",
+            "keywords": [
+                "phpcs",
+                "standards",
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/Automattic/VIP-Coding-Standards/issues",
+                "source": "https://github.com/Automattic/VIP-Coding-Standards",
+                "wiki": "https://github.com/Automattic/VIP-Coding-Standards/wiki"
+            },
+            "time": "2021-09-29T16:20:23+00:00"
+        },
         {
             "name": "behat/behat",
             "version": "v3.12.0",
@@ -555,38 +607,35 @@
         },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
-            "version": "v1.0.0",
+            "version": "v0.7.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/PHPCSStandards/composer-installer.git",
-                "reference": "4be43904336affa5c2f70744a348312336afd0da"
+                "url": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer.git",
+                "reference": "1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/4be43904336affa5c2f70744a348312336afd0da",
-                "reference": "4be43904336affa5c2f70744a348312336afd0da",
+                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db",
+                "reference": "1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db",
                 "shasum": ""
             },
             "require": {
                 "composer-plugin-api": "^1.0 || ^2.0",
-                "php": ">=5.4",
+                "php": ">=5.3",
                 "squizlabs/php_codesniffer": "^2.0 || ^3.1.0 || ^4.0"
             },
             "require-dev": {
                 "composer/composer": "*",
-                "ext-json": "*",
-                "ext-zip": "*",
                 "php-parallel-lint/php-parallel-lint": "^1.3.1",
-                "phpcompatibility/php-compatibility": "^9.0",
-                "yoast/phpunit-polyfills": "^1.0"
+                "phpcompatibility/php-compatibility": "^9.0"
             },
             "type": "composer-plugin",
             "extra": {
-                "class": "PHPCSStandards\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
+                "class": "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
             },
             "autoload": {
                 "psr-4": {
-                    "PHPCSStandards\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
+                    "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -602,7 +651,7 @@
                 },
                 {
                     "name": "Contributors",
-                    "homepage": "https://github.com/PHPCSStandards/composer-installer/graphs/contributors"
+                    "homepage": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer/graphs/contributors"
                 }
             ],
             "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
@@ -626,10 +675,10 @@
                 "tests"
             ],
             "support": {
-                "issues": "https://github.com/PHPCSStandards/composer-installer/issues",
-                "source": "https://github.com/PHPCSStandards/composer-installer"
+                "issues": "https://github.com/dealerdirect/phpcodesniffer-composer-installer/issues",
+                "source": "https://github.com/dealerdirect/phpcodesniffer-composer-installer"
             },
-            "time": "2023-01-05T11:28:13+00:00"
+            "time": "2022-02-04T12:51:07+00:00"
         },
         {
             "name": "doctrine/instantiator",
@@ -760,6 +809,62 @@
             },
             "abandoned": "symfony/browser-kit",
             "time": "2020-11-01T09:30:18+00:00"
+        },
+        {
+            "name": "fig-r/psr2r-sniffer",
+            "version": "1.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig-rectified/psr2r-sniffer.git",
+                "reference": "53ca1ecd62b0dc2ab8ea48635f583cb361c5e8f2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig-rectified/psr2r-sniffer/zipball/53ca1ecd62b0dc2ab8ea48635f583cb361c5e8f2",
+                "reference": "53ca1ecd62b0dc2ab8ea48635f583cb361c5e8f2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "slevomat/coding-standard": "^7.2.0 || ^8.3.0",
+                "spryker/code-sniffer": "^0.17.1",
+                "squizlabs/php_codesniffer": "^3.7.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.0.0"
+            },
+            "bin": [
+                "bin/tokenize",
+                "bin/sniff"
+            ],
+            "type": "phpcodesniffer-standard",
+            "autoload": {
+                "psr-4": {
+                    "PSR2R\\": "PSR2R/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mark Scherer",
+                    "homepage": "https://www.dereuromark.de",
+                    "role": "Contributor"
+                }
+            ],
+            "description": "Code-Sniffer, Auto-Fixer and Tokenizer for PSR2-R",
+            "keywords": [
+                "codesniffer",
+                "cs",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig-rectified/psr2r-sniffer/issues",
+                "source": "https://github.com/php-fig-rectified/psr2r-sniffer/tree/1.5.0"
+            },
+            "time": "2023-01-01T15:31:05+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",
@@ -1220,6 +1325,48 @@
             "time": "2020-04-17T11:46:11+00:00"
         },
         {
+            "name": "pantheon-systems/pantheon-wp-coding-standards",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pantheon-systems/Pantheon-WP-Coding-Standards.git",
+                "reference": "1e8fb654d52b9274f548c46f89d98f4913307fdf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pantheon-systems/Pantheon-WP-Coding-Standards/zipball/1e8fb654d52b9274f548c46f89d98f4913307fdf",
+                "reference": "1e8fb654d52b9274f548c46f89d98f4913307fdf",
+                "shasum": ""
+            },
+            "require": {
+                "automattic/vipwpcs": "^2.3",
+                "fig-r/psr2r-sniffer": "^1.5",
+                "phpcompatibility/phpcompatibility-wp": "^2.1",
+                "wp-coding-standards/wpcs": "^2.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "9.6.x-dev",
+                "yoast/phpunit-polyfills": "1.x-dev"
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Pantheon",
+                    "email": "noreply@pantheon.io"
+                }
+            ],
+            "description": "PHPCS Rulesets for WordPress projects on Pantheon.",
+            "support": {
+                "issues": "https://github.com/pantheon-systems/Pantheon-WP-Coding-Standards/issues",
+                "source": "https://github.com/pantheon-systems/Pantheon-WP-Coding-Standards/tree/1.0.1"
+            },
+            "time": "2023-04-14T16:54:02+00:00"
+        },
+        {
             "name": "phar-io/manifest",
             "version": "2.0.3",
             "source": {
@@ -1393,141 +1540,161 @@
             "time": "2019-12-27T09:44:58+00:00"
         },
         {
-            "name": "phpcsstandards/phpcsextra",
-            "version": "1.0.3",
+            "name": "phpcompatibility/phpcompatibility-paragonie",
+            "version": "1.3.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/PHPCSStandards/PHPCSExtra.git",
-                "reference": "7029c051cd310e2e17c6caea3429bfbe290c41ae"
+                "url": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie.git",
+                "reference": "bba5a9dfec7fcfbd679cfaf611d86b4d3759da26"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSExtra/zipball/7029c051cd310e2e17c6caea3429bfbe290c41ae",
-                "reference": "7029c051cd310e2e17c6caea3429bfbe290c41ae",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityParagonie/zipball/bba5a9dfec7fcfbd679cfaf611d86b4d3759da26",
+                "reference": "bba5a9dfec7fcfbd679cfaf611d86b4d3759da26",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.4",
-                "phpcsstandards/phpcsutils": "^1.0",
-                "squizlabs/php_codesniffer": "^3.7.1"
+                "phpcompatibility/php-compatibility": "^9.0"
             },
             "require-dev": {
-                "php-parallel-lint/php-console-highlighter": "^1.0",
-                "php-parallel-lint/php-parallel-lint": "^1.3.2",
-                "phpcsstandards/phpcsdevcs": "^1.1.5",
-                "phpcsstandards/phpcsdevtools": "^1.2.0",
-                "phpunit/phpunit": "^4.5 || ^5.0 || ^6.0 || ^7.0"
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
+                "paragonie/random_compat": "dev-master",
+                "paragonie/sodium_compat": "dev-master"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
             },
             "type": "phpcodesniffer-standard",
-            "extra": {
-                "branch-alias": {
-                    "dev-stable": "1.x-dev",
-                    "dev-develop": "1.x-dev"
-                }
-            },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "LGPL-3.0-or-later"
             ],
             "authors": [
                 {
-                    "name": "Juliette Reinders Folmer",
-                    "homepage": "https://github.com/jrfnl",
+                    "name": "Wim Godden",
                     "role": "lead"
                 },
                 {
-                    "name": "Contributors",
-                    "homepage": "https://github.com/PHPCSStandards/PHPCSExtra/graphs/contributors"
+                    "name": "Juliette Reinders Folmer",
+                    "role": "lead"
                 }
             ],
-            "description": "A collection of sniffs and standards for use with PHP_CodeSniffer.",
+            "description": "A set of rulesets for PHP_CodeSniffer to check for PHP cross-version compatibility issues in projects, while accounting for polyfills provided by the Paragonie polyfill libraries.",
+            "homepage": "http://phpcompatibility.com/",
             "keywords": [
-                "PHP_CodeSniffer",
-                "phpcbf",
-                "phpcodesniffer-standard",
+                "compatibility",
+                "paragonie",
                 "phpcs",
+                "polyfill",
                 "standards",
                 "static analysis"
             ],
             "support": {
-                "issues": "https://github.com/PHPCSStandards/PHPCSExtra/issues",
-                "source": "https://github.com/PHPCSStandards/PHPCSExtra"
+                "issues": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie/issues",
+                "source": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie"
             },
-            "time": "2023-03-28T17:48:27+00:00"
+            "time": "2022-10-25T01:46:02+00:00"
         },
         {
-            "name": "phpcsstandards/phpcsutils",
-            "version": "1.0.2",
+            "name": "phpcompatibility/phpcompatibility-wp",
+            "version": "2.1.4",
             "source": {
                 "type": "git",
-                "url": "https://github.com/PHPCSStandards/PHPCSUtils.git",
-                "reference": "e74812ac026d9f9f18a936d29880b2db3211f89d"
+                "url": "https://github.com/PHPCompatibility/PHPCompatibilityWP.git",
+                "reference": "b6c1e3ee1c35de6c41a511d5eb9bd03e447480a5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/e74812ac026d9f9f18a936d29880b2db3211f89d",
-                "reference": "e74812ac026d9f9f18a936d29880b2db3211f89d",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityWP/zipball/b6c1e3ee1c35de6c41a511d5eb9bd03e447480a5",
+                "reference": "b6c1e3ee1c35de6c41a511d5eb9bd03e447480a5",
                 "shasum": ""
             },
             "require": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7 || ^1.0",
-                "php": ">=5.4",
-                "squizlabs/php_codesniffer": "^3.7.1 || 4.0.x-dev@dev"
+                "phpcompatibility/php-compatibility": "^9.0",
+                "phpcompatibility/phpcompatibility-paragonie": "^1.0"
             },
             "require-dev": {
-                "ext-filter": "*",
-                "php-parallel-lint/php-console-highlighter": "^1.0",
-                "php-parallel-lint/php-parallel-lint": "^1.3.2",
-                "phpcsstandards/phpcsdevcs": "^1.1.3",
-                "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.3",
-                "yoast/phpunit-polyfills": "^1.0.1"
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
             },
             "type": "phpcodesniffer-standard",
-            "extra": {
-                "branch-alias": {
-                    "dev-stable": "1.x-dev",
-                    "dev-develop": "1.x-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "PHPCSUtils/"
-                ]
-            },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "LGPL-3.0-or-later"
             ],
             "authors": [
                 {
-                    "name": "Juliette Reinders Folmer",
-                    "homepage": "https://github.com/jrfnl",
+                    "name": "Wim Godden",
                     "role": "lead"
                 },
                 {
-                    "name": "Contributors",
-                    "homepage": "https://github.com/PHPCSStandards/PHPCSUtils/graphs/contributors"
+                    "name": "Juliette Reinders Folmer",
+                    "role": "lead"
                 }
             ],
-            "description": "A suite of utility functions for use with PHP_CodeSniffer",
-            "homepage": "https://phpcsutils.com/",
+            "description": "A ruleset for PHP_CodeSniffer to check for PHP cross-version compatibility issues in projects, while accounting for polyfills provided by WordPress.",
+            "homepage": "http://phpcompatibility.com/",
             "keywords": [
-                "PHP_CodeSniffer",
-                "phpcbf",
-                "phpcodesniffer-standard",
+                "compatibility",
                 "phpcs",
-                "phpcs3",
                 "standards",
                 "static analysis",
-                "tokens",
-                "utility"
+                "wordpress"
             ],
             "support": {
-                "docs": "https://phpcsutils.com/",
-                "issues": "https://github.com/PHPCSStandards/PHPCSUtils/issues",
-                "source": "https://github.com/PHPCSStandards/PHPCSUtils"
+                "issues": "https://github.com/PHPCompatibility/PHPCompatibilityWP/issues",
+                "source": "https://github.com/PHPCompatibility/PHPCompatibilityWP"
             },
-            "time": "2023-03-28T16:57:37+00:00"
+            "time": "2022-10-24T09:00:36+00:00"
+        },
+        {
+            "name": "phpstan/phpdoc-parser",
+            "version": "1.18.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpdoc-parser.git",
+                "reference": "22dcdfd725ddf99583bfe398fc624ad6c5004a0f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/22dcdfd725ddf99583bfe398fc624ad6c5004a0f",
+                "reference": "22dcdfd725ddf99583bfe398fc624ad6c5004a0f",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^1.5",
+                "phpstan/phpstan-phpunit": "^1.1",
+                "phpstan/phpstan-strict-rules": "^1.0",
+                "phpunit/phpunit": "^9.5",
+                "symfony/process": "^5.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\PhpDocParser\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPDoc parser with support for nullable, intersection and generic types",
+            "support": {
+                "issues": "https://github.com/phpstan/phpdoc-parser/issues",
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.18.1"
+            },
+            "time": "2023-04-07T11:51:11+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -1849,16 +2016,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.6",
+            "version": "9.6.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "b65d59a059d3004a040c16a82e07bbdf6cfdd115"
+                "reference": "c993f0d3b0489ffc42ee2fe0bd645af1538a63b2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/b65d59a059d3004a040c16a82e07bbdf6cfdd115",
-                "reference": "b65d59a059d3004a040c16a82e07bbdf6cfdd115",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/c993f0d3b0489ffc42ee2fe0bd645af1538a63b2",
+                "reference": "c993f0d3b0489ffc42ee2fe0bd645af1538a63b2",
                 "shasum": ""
             },
             "require": {
@@ -1932,7 +2099,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.6"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.7"
             },
             "funding": [
                 {
@@ -1948,7 +2115,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-03-27T11:43:46+00:00"
+            "time": "2023-04-14T08:58:40+00:00"
         },
         {
             "name": "psr/container",
@@ -3108,6 +3275,187 @@
                 }
             ],
             "time": "2020-09-28T06:39:44+00:00"
+        },
+        {
+            "name": "sirbrillig/phpcs-variable-analysis",
+            "version": "v2.11.16",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sirbrillig/phpcs-variable-analysis.git",
+                "reference": "dc5582dc5a93a235557af73e523c389aac9a8e88"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sirbrillig/phpcs-variable-analysis/zipball/dc5582dc5a93a235557af73e523c389aac9a8e88",
+                "reference": "dc5582dc5a93a235557af73e523c389aac9a8e88",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0",
+                "squizlabs/php_codesniffer": "^3.5.6"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7 || ^1.0",
+                "phpcsstandards/phpcsdevcs": "^1.1",
+                "phpstan/phpstan": "^1.7",
+                "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.5 || ^7.0 || ^8.0 || ^9.0",
+                "sirbrillig/phpcs-import-detection": "^1.1",
+                "vimeo/psalm": "^0.2 || ^0.3 || ^1.1 || ^4.24 || ^5.0@beta"
+            },
+            "type": "phpcodesniffer-standard",
+            "autoload": {
+                "psr-4": {
+                    "VariableAnalysis\\": "VariableAnalysis/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sam Graham",
+                    "email": "php-codesniffer-variableanalysis@illusori.co.uk"
+                },
+                {
+                    "name": "Payton Swick",
+                    "email": "payton@foolord.com"
+                }
+            ],
+            "description": "A PHPCS sniff to detect problems with variables.",
+            "keywords": [
+                "phpcs",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/sirbrillig/phpcs-variable-analysis/issues",
+                "source": "https://github.com/sirbrillig/phpcs-variable-analysis",
+                "wiki": "https://github.com/sirbrillig/phpcs-variable-analysis/wiki"
+            },
+            "time": "2023-03-31T16:46:32+00:00"
+        },
+        {
+            "name": "slevomat/coding-standard",
+            "version": "8.10.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/slevomat/coding-standard.git",
+                "reference": "c4e213e6e57f741451a08e68ef838802eec92287"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/c4e213e6e57f741451a08e68ef838802eec92287",
+                "reference": "c4e213e6e57f741451a08e68ef838802eec92287",
+                "shasum": ""
+            },
+            "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7 || ^1.0",
+                "php": "^7.2 || ^8.0",
+                "phpstan/phpdoc-parser": ">=1.18.0 <1.19.0",
+                "squizlabs/php_codesniffer": "^3.7.1"
+            },
+            "require-dev": {
+                "phing/phing": "2.17.4",
+                "php-parallel-lint/php-parallel-lint": "1.3.2",
+                "phpstan/phpstan": "1.4.10|1.10.11",
+                "phpstan/phpstan-deprecation-rules": "1.1.3",
+                "phpstan/phpstan-phpunit": "1.0.0|1.3.11",
+                "phpstan/phpstan-strict-rules": "1.5.1",
+                "phpunit/phpunit": "7.5.20|8.5.21|9.6.6|10.0.19"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "8.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "SlevomatCodingStandard\\": "SlevomatCodingStandard/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Slevomat Coding Standard for PHP_CodeSniffer complements Consistence Coding Standard by providing sniffs with additional checks.",
+            "keywords": [
+                "dev",
+                "phpcs"
+            ],
+            "support": {
+                "issues": "https://github.com/slevomat/coding-standard/issues",
+                "source": "https://github.com/slevomat/coding-standard/tree/8.10.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/kukulich",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/slevomat/coding-standard",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-04-10T07:39:29+00:00"
+        },
+        {
+            "name": "spryker/code-sniffer",
+            "version": "0.17.18",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spryker/code-sniffer.git",
+                "reference": "5fb8b573abc4a906d0d364a4a03abd38e565ba29"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spryker/code-sniffer/zipball/5fb8b573abc4a906d0d364a4a03abd38e565ba29",
+                "reference": "5fb8b573abc4a906d0d364a4a03abd38e565ba29",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.4",
+                "slevomat/coding-standard": "^7.2.0 || ^8.0.1",
+                "squizlabs/php_codesniffer": "^3.6.2"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.0.0",
+                "phpunit/phpunit": "^9.5"
+            },
+            "bin": [
+                "bin/tokenize"
+            ],
+            "type": "phpcodesniffer-standard",
+            "autoload": {
+                "psr-4": {
+                    "Spryker\\": "Spryker/",
+                    "SprykerStrict\\": "SprykerStrict/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Spryker",
+                    "homepage": "https://spryker.com"
+                }
+            ],
+            "description": "Spryker Code Sniffer Standards",
+            "homepage": "https://spryker.com",
+            "keywords": [
+                "codesniffer",
+                "framework",
+                "phpcs",
+                "standards",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/spryker/code-sniffer/issues",
+                "source": "https://github.com/spryker/code-sniffer"
+            },
+            "time": "2023-01-03T16:08:22+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
@@ -5131,36 +5479,31 @@
         },
         {
             "name": "wp-coding-standards/wpcs",
-            "version": "dev-develop",
+            "version": "2.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
-                "reference": "2e76b2061246fbee2ea8461c57b67b6b0c010223"
+                "reference": "7da1894633f168fe244afc6de00d141f27517b62"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/2e76b2061246fbee2ea8461c57b67b6b0c010223",
-                "reference": "2e76b2061246fbee2ea8461c57b67b6b0c010223",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/7da1894633f168fe244afc6de00d141f27517b62",
+                "reference": "7da1894633f168fe244afc6de00d141f27517b62",
                 "shasum": ""
             },
             "require": {
-                "ext-filter": "*",
                 "php": ">=5.4",
-                "phpcsstandards/phpcsextra": "^1.0",
-                "phpcsstandards/phpcsutils": "^1.0",
-                "squizlabs/php_codesniffer": "^3.7.2"
+                "squizlabs/php_codesniffer": "^3.3.1"
             },
             "require-dev": {
-                "php-parallel-lint/php-console-highlighter": "^1.0.0",
-                "php-parallel-lint/php-parallel-lint": "^1.3.2",
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || ^0.6",
                 "phpcompatibility/php-compatibility": "^9.0",
-                "phpcsstandards/phpcsdevtools": "^1.2.0",
+                "phpcsstandards/phpcsdevtools": "^1.0",
                 "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
             },
             "suggest": {
-                "ext-mbstring": "For improved results"
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.6 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
             },
-            "default-branch": true,
             "type": "phpcodesniffer-standard",
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -5176,7 +5519,6 @@
             "keywords": [
                 "phpcs",
                 "standards",
-                "static analysis",
                 "wordpress"
             ],
             "support": {
@@ -5184,7 +5526,7 @@
                 "source": "https://github.com/WordPress/WordPress-Coding-Standards",
                 "wiki": "https://github.com/WordPress/WordPress-Coding-Standards/wiki"
             },
-            "time": "2023-03-27T21:12:05+00:00"
+            "time": "2020-05-13T23:57:56+00:00"
         },
         {
             "name": "yoast/phpunit-polyfills",
@@ -5247,18 +5589,10 @@
             "time": "2023-03-30T23:39:05+00:00"
         }
     ],
-    "aliases": [
-        {
-            "package": "wp-coding-standards/wpcs",
-            "version": "dev-develop",
-            "alias": "2.3.1",
-            "alias_normalized": "2.3.1.0"
-        }
-    ],
+    "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
-        "pantheon-systems/pantheon-wordpress-upstream-tests": 20,
-        "wp-coding-standards/wpcs": 20
+        "pantheon-systems/pantheon-wordpress-upstream-tests": 20
     },
     "prefer-stable": true,
     "prefer-lowest": false,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "773059593163b7454eeac937771b7b2d",
+    "content-hash": "2c8582bf65c0c2d0ae1356022bee50b9",
     "packages": [
         {
             "name": "onelogin/php-saml",
@@ -1231,16 +1231,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.15.4",
+            "version": "v4.15.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "6bb5176bc4af8bcb7d926f88718db9b96a2d4290"
+                "reference": "11e2663a5bc9db5d714eedb4277ee300403b4a9e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/6bb5176bc4af8bcb7d926f88718db9b96a2d4290",
-                "reference": "6bb5176bc4af8bcb7d926f88718db9b96a2d4290",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/11e2663a5bc9db5d714eedb4277ee300403b4a9e",
+                "reference": "11e2663a5bc9db5d714eedb4277ee300403b4a9e",
                 "shasum": ""
             },
             "require": {
@@ -1281,9 +1281,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.15.4"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.15.5"
             },
-            "time": "2023-03-05T19:49:14+00:00"
+            "time": "2023-05-19T20:20:00+00:00"
         },
         {
             "name": "pantheon-systems/pantheon-wordpress-upstream-tests",
@@ -2016,16 +2016,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.7",
+            "version": "9.6.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "c993f0d3b0489ffc42ee2fe0bd645af1538a63b2"
+                "reference": "a9aceaf20a682aeacf28d582654a1670d8826778"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/c993f0d3b0489ffc42ee2fe0bd645af1538a63b2",
-                "reference": "c993f0d3b0489ffc42ee2fe0bd645af1538a63b2",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/a9aceaf20a682aeacf28d582654a1670d8826778",
+                "reference": "a9aceaf20a682aeacf28d582654a1670d8826778",
                 "shasum": ""
             },
             "require": {
@@ -2099,7 +2099,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.7"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.9"
             },
             "funding": [
                 {
@@ -2115,7 +2115,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-04-14T08:58:40+00:00"
+            "time": "2023-06-11T06:13:56+00:00"
         },
         {
             "name": "psr/container",
@@ -2612,16 +2612,16 @@
         },
         {
             "name": "sebastian/diff",
-            "version": "4.0.4",
+            "version": "4.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "3461e3fccc7cfdfc2720be910d3bd73c69be590d"
+                "reference": "74be17022044ebaaecfdf0c5cd504fc9cd5a7131"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/3461e3fccc7cfdfc2720be910d3bd73c69be590d",
-                "reference": "3461e3fccc7cfdfc2720be910d3bd73c69be590d",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/74be17022044ebaaecfdf0c5cd504fc9cd5a7131",
+                "reference": "74be17022044ebaaecfdf0c5cd504fc9cd5a7131",
                 "shasum": ""
             },
             "require": {
@@ -2666,7 +2666,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/diff/issues",
-                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.4"
+                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.5"
             },
             "funding": [
                 {
@@ -2674,7 +2674,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:10:38+00:00"
+            "time": "2023-05-07T05:35:17+00:00"
         },
         {
             "name": "sebastian/environment",
@@ -5530,21 +5530,21 @@
         },
         {
             "name": "yoast/phpunit-polyfills",
-            "version": "1.0.5",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
-                "reference": "3b59adeef77fb1c03ff5381dbb9d68b0aaff3171"
+                "reference": "c758753e8f9dac251fed396a73c8305af3f17922"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/3b59adeef77fb1c03ff5381dbb9d68b0aaff3171",
-                "reference": "3b59adeef77fb1c03ff5381dbb9d68b0aaff3171",
+                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/c758753e8f9dac251fed396a73c8305af3f17922",
+                "reference": "c758753e8f9dac251fed396a73c8305af3f17922",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.4",
-                "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
+                "php": ">=5.6",
+                "phpunit/phpunit": "^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0"
             },
             "require-dev": {
                 "yoast/yoastcs": "^2.3.0"
@@ -5586,7 +5586,7 @@
                 "issues": "https://github.com/Yoast/PHPUnit-Polyfills/issues",
                 "source": "https://github.com/Yoast/PHPUnit-Polyfills"
             },
-            "time": "2023-03-30T23:39:05+00:00"
+            "time": "2023-06-06T20:28:24+00:00"
         }
     ],
     "aliases": [],

--- a/composer.lock
+++ b/composer.lock
@@ -4222,16 +4222,16 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v5.4.21",
+            "version": "v5.4.23",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "e75960b1bbfd2b8c9e483e0d74811d555ca3de9f"
+                "reference": "b2f79d86cd9e7de0fff6d03baa80eaed7a5f38b5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/e75960b1bbfd2b8c9e483e0d74811d555ca3de9f",
-                "reference": "e75960b1bbfd2b8c9e483e0d74811d555ca3de9f",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/b2f79d86cd9e7de0fff6d03baa80eaed7a5f38b5",
+                "reference": "b2f79d86cd9e7de0fff6d03baa80eaed7a5f38b5",
                 "shasum": ""
             },
             "require": {
@@ -4266,7 +4266,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v5.4.21"
+                "source": "https://github.com/symfony/filesystem/tree/v5.4.23"
             },
             "funding": [
                 {
@@ -4282,7 +4282,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-02-14T08:03:56+00:00"
+            "time": "2023-03-02T11:38:35+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",

--- a/inc/class-wp-saml-auth-cli.php
+++ b/inc/class-wp-saml-auth-cli.php
@@ -89,7 +89,7 @@ class WP_SAML_Auth_CLI {
 	 * @return string
 	 */
 	protected static function scaffold_config_function( $assoc_args ) {
-		$defaults   = array(
+		$defaults   = [
 			'type'                   => 'internal',
 			'simplesamlphp_autoload' => __DIR__ . '/simplesamlphp/lib/_autoload.php',
 			'auth_source'            => 'default-sp',
@@ -102,20 +102,20 @@ class WP_SAML_Auth_CLI {
 			'first_name_attribute'   => 'first_name',
 			'last_name_attribute'    => 'last_name',
 			'default_role'           => get_option( 'default_role' ),
-		);
+		];
 		$assoc_args = array_merge( $defaults, $assoc_args );
 
-		foreach ( array( 'auto_provision', 'permit_wp_login' ) as $bool ) {
+		foreach ( [ 'auto_provision', 'permit_wp_login' ] as $bool ) {
 			// Support --auto_provision=false passed as an argument.
 			$assoc_args[ $bool ] = 'false' === $assoc_args[ $bool ] ? false : (bool) $assoc_args[ $bool ];
 		}
 
-		$values = var_export( $assoc_args, true );
+		$values = var_export( $assoc_args, true ); //phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export
 		// Formatting fixes.
-		$search_replace = array(
+		$search_replace = [
 			'  '      => "\t\t",
 			'array (' => 'array(',
-		);
+		];
 		$values         = str_replace( array_keys( $search_replace ), array_values( $search_replace ), $values );
 		$values         = rtrim( $values, ')' ) . "\t);";
 		$function       = <<<EOT

--- a/inc/class-wp-saml-auth-options.php
+++ b/inc/class-wp-saml-auth-options.php
@@ -25,7 +25,7 @@ class WP_SAML_Auth_Options {
 	public static function get_instance() {
 		if ( ! isset( self::$instance ) ) {
 			self::$instance = new WP_SAML_Auth_Options();
-			add_action( 'init', array( self::$instance, 'action_init_early' ), 9 );
+			add_action( 'init', [ self::$instance, 'action_init_early' ], 9 );
 		}
 		return self::$instance;
 	}
@@ -40,7 +40,7 @@ class WP_SAML_Auth_Options {
 		if ( self::do_required_settings_have_values() ) {
 			add_filter(
 				'wp_saml_auth_option',
-				array( self::$instance, 'filter_option' ),
+				[ self::$instance, 'filter_option' ],
 				9,
 				2
 			);
@@ -63,7 +63,7 @@ class WP_SAML_Auth_Options {
 	 */
 	public static function has_settings_filter() {
 		$filter1    = remove_filter( 'wp_saml_auth_option', 'wpsa_filter_option', 0 );
-		$filter2    = remove_filter( 'wp_saml_auth_option', array( self::$instance, 'filter_option' ), 9 );
+		$filter2    = remove_filter( 'wp_saml_auth_option', [ self::$instance, 'filter_option' ], 9 );
 		$has_filter = has_filter( 'wp_saml_auth_option' );
 		if ( $filter1 ) {
 			add_filter( 'wp_saml_auth_option', 'wpsa_filter_option', 0, 2 );
@@ -71,7 +71,7 @@ class WP_SAML_Auth_Options {
 		if ( $filter2 ) {
 			add_filter(
 				'wp_saml_auth_option',
-				array( self::$instance, 'filter_option' ),
+				[ self::$instance, 'filter_option' ],
 				9,
 				2
 			);
@@ -117,37 +117,37 @@ class WP_SAML_Auth_Options {
 			$x509cert = str_replace( 'ABSPATH', ABSPATH, $options['x509cert'] );
 			$x509cert = file_exists( $x509cert ) ? file_get_contents( $x509cert ) : '';
 		}
-		$settings = array(
+		$settings = [
 			'connection_type' => 'internal',
-			'internal_config' => array(
+			'internal_config' => [
 				'strict'  => true,
 				'debug'   => defined( 'WP_DEBUG' ) && WP_DEBUG ? true : false,
 				'baseurl' => $options['baseurl'],
-				'sp'      => array(
+				'sp'      => [
 					'entityId'                 => $options['sp_entityId'],
-					'assertionConsumerService' => array(
+					'assertionConsumerService' => [
 						'url'     => $options['sp_assertionConsumerService_url'],
 						'binding' => 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST',
-					),
-				),
-				'idp'     => array(
+					],
+				],
+				'idp'     => [
 					'entityId'                 => $options['idp_entityId'],
-					'singleSignOnService'      => array(
+					'singleSignOnService'      => [
 						'url'     => $options['idp_singleSignOnService_url'],
 						'binding' => 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect',
-					),
-					'singleLogoutService'      => array(
+					],
+					'singleLogoutService'      => [
 						'url'     => $options['idp_singleLogoutService_url'],
 						'binding' => 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect',
-					),
+					],
 					'x509cert'                 => $x509cert,
 					'certFingerprint'          => $options['certFingerprint'],
 					'certFingerprintAlgorithm' => $options['certFingerprintAlgorithm'],
-				),
-			),
-		);
+				],
+			],
+		];
 
-		$remaining_settings = array(
+		$remaining_settings = [
 			'auto_provision',
 			'permit_wp_login',
 			'get_user_by',
@@ -156,7 +156,7 @@ class WP_SAML_Auth_Options {
 			'display_name_attribute',
 			'first_name_attribute',
 			'last_name_attribute',
-		);
+		];
 		foreach ( $remaining_settings as $setting ) {
 			$settings[ $setting ] = $options[ $setting ];
 		}

--- a/inc/class-wp-saml-auth-settings.php
+++ b/inc/class-wp-saml-auth-settings.php
@@ -61,13 +61,13 @@ class WP_SAML_Auth_Settings {
 		if ( ! isset( self::$instance ) ) {
 			self::$instance = new WP_SAML_Auth_Settings();
 
-			add_action( 'admin_init', array( self::$instance, 'admin_init' ) );
-			add_action( 'admin_menu', array( self::$instance, 'admin_menu' ) );
+			add_action( 'admin_init', [ self::$instance, 'admin_init' ] );
+			add_action( 'admin_menu', [ self::$instance, 'admin_menu' ] );
 
 			add_filter(
 				'plugin_action_links_' . plugin_basename( dirname( plugin_dir_path( __FILE__ ) ) ) .
 					'/wp-saml-auth.php',
-				array( self::$instance, 'plugin_settings_link' )
+				[ self::$instance, 'plugin_settings_link' ]
 			);
 		}
 		return self::$instance;
@@ -80,7 +80,7 @@ class WP_SAML_Auth_Settings {
 		register_setting(
 			self::$option_group,
 			WP_SAML_Auth_Options::get_option_name(),
-			array( 'sanitize_callback' => array( self::$instance, 'sanitize_callback' ) )
+			[ 'sanitize_callback' => [ self::$instance, 'sanitize_callback' ] ]
 		);
 		self::setup_sections();
 		self::setup_fields();
@@ -95,7 +95,7 @@ class WP_SAML_Auth_Settings {
 			__( 'WP SAML Auth', 'wp-saml-auth' ),
 			self::$capability,
 			self::$menu_slug,
-			array( self::$instance, 'render_page_content' )
+			[ self::$instance, 'render_page_content' ]
 		);
 	}
 
@@ -118,7 +118,7 @@ class WP_SAML_Auth_Settings {
 						$markup .= '<option value="' . esc_attr( $key ) . '" ' . selected( $value, $key, false ) . '>' . esc_html( $label ) .
 									'</option>';
 					}
-					printf( '<select name="%1$s" id="%1$s">%2$s</select>', esc_attr( $uid ), $markup );
+					printf( '<select name="%1$s" id="%1$s">%2$s</select>', esc_attr( $uid ), $markup ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 				}
 				break;
 			case 'text':
@@ -140,6 +140,11 @@ class WP_SAML_Auth_Settings {
 	 * Render the settings page
 	 */
 	public static function render_page_content() {
+		$allowed_html = [
+			'a' => [
+				'href' => [],
+			],
+		];
 		?>
 		<div class="wrap">
 			<h2><?php esc_html_e( 'WP SAML Auth Settings', 'wp-saml-auth' ); ?></h2>
@@ -147,14 +152,14 @@ class WP_SAML_Auth_Settings {
 				<p>
 				<?php
 				// translators: Link to the plugin settings page.
-				echo sprintf( __( 'Settings are defined with a filter and unavailable for editing through the backend. <a href="%s">Visit the plugin page</a> for more information.', 'wp-saml-auth' ), 'https://wordpress.org/plugins/wp-saml-auth/' );
+				echo sprintf( wp_kses( __( 'Settings are defined with a filter and unavailable for editing through the backend. <a href="%s">Visit the plugin page</a> for more information.', 'wp-saml-auth' ), $allowed_html ), 'https://wordpress.org/plugins/wp-saml-auth/' );
 				?>
 				</p>
 			<?php else : ?>
 				<p>
 				<?php
 				// translators: Link to the plugin settings page.
-				echo sprintf( __( 'Use the following settings to configure WP SAML Auth with the \'internal\' connection type. <a href="%s">Visit the plugin page</a> for more information.', 'wp-saml-auth' ), 'https://wordpress.org/plugins/wp-saml-auth/' );
+				echo sprintf( wp_kses( __( 'Use the following settings to configure WP SAML Auth with the \'internal\' connection type. <a href="%s">Visit the plugin page</a> for more information.', 'wp-saml-auth' ), $allowed_html ), 'https://wordpress.org/plugins/wp-saml-auth/' );
 				?>
 				</p>
 				<?php if ( WP_SAML_Auth_Options::do_required_settings_have_values() ) : ?>
@@ -194,7 +199,7 @@ class WP_SAML_Auth_Settings {
 	 */
 	public static function sanitize_callback( $input ) {
 		if ( empty( $input ) || ! is_array( $input ) ) {
-			return array();
+			return [];
 		}
 
 		foreach ( self::$fields as $field ) {
@@ -231,7 +236,7 @@ class WP_SAML_Auth_Settings {
 			if ( 'url' === $field['type'] ) {
 				if ( ! empty( $value ) ) {
 					if ( filter_var( $value, FILTER_VALIDATE_URL ) ) {
-						$input[ $uid ] = esc_url_raw( $value, array( 'http', 'https' ) );
+						$input[ $uid ] = esc_url_raw( $value, [ 'http', 'https' ] );
 					} else {
 						$input['connection_type'] = null;
 						$input[ $uid ]            = null;
@@ -278,7 +283,7 @@ class WP_SAML_Auth_Settings {
 			add_settings_field(
 				$field['uid'],
 				$field['label'],
-				array( self::$instance, 'field_callback' ),
+				[ self::$instance, 'field_callback' ],
 				WP_SAML_Auth_Options::get_option_name(),
 				$field['section'],
 				$field
@@ -290,12 +295,12 @@ class WP_SAML_Auth_Settings {
 	 * Initialize the sections array and add settings sections
 	 */
 	public static function setup_sections() {
-		self::$sections = array(
+		self::$sections = [
 			'general'    => '',
 			'sp'         => __( 'Service Provider Settings', 'wp-saml-auth' ),
 			'idp'        => __( 'Identity Provider Settings', 'wp-saml-auth' ),
 			'attributes' => __( 'Attribute Mappings', 'wp-saml-auth' ),
-		);
+		];
 		foreach ( self::$sections as $id => $title ) {
 			add_settings_section( $id, $title, null, WP_SAML_Auth_Options::get_option_name() );
 		}
@@ -305,46 +310,46 @@ class WP_SAML_Auth_Settings {
 	 * Initialize the fields array
 	 */
 	public static function init_fields() {
-		self::$fields = array(
+		self::$fields = [
 			// general section.
-			array(
+			[
 				'section'     => 'general',
 				'uid'         => 'auto_provision',
 				'label'       => __( 'Auto Provision', 'wp-saml-auth' ),
 				'type'        => 'checkbox',
 				'description' => __( 'If checked, create a new WordPress user upon login. <br>If unchecked, WordPress user will already need to exist in order to log in.', 'wp-saml-auth' ),
 				'default'     => 'true',
-			),
-			array(
+			],
+			[
 				'section'     => 'general',
 				'uid'         => 'permit_wp_login',
 				'label'       => __( 'Permit WordPress login', 'wp-saml-auth' ),
 				'type'        => 'checkbox',
 				'description' => __( 'If checked, WordPress user can also log in with the standard username and password flow.', 'wp-saml-auth' ),
 				'default'     => 'true',
-			),
-			array(
+			],
+			[
 				'section'     => 'general',
 				'uid'         => 'get_user_by',
 				'label'       => __( 'Get User By', 'wp-saml-auth' ),
 				'type'        => 'select',
-				'choices'     => array(
+				'choices'     => [
 					'email' => 'email',
 					'login' => 'login',
-				),
+				],
 				'description' => __( 'Attribute by which SAML requests are matched to WordPress users.', 'wp-saml-auth' ),
 				'default'     => 'email',
-			),
-			array(
+			],
+			[
 				'section'     => 'general',
 				'uid'         => 'baseurl',
 				'label'       => __( 'Base URL', 'wp-saml-auth' ),
 				'type'        => 'url',
 				'description' => __( 'The base url to be used when constructing URLs.', 'wp-saml-auth' ),
 				'default'     => home_url(),
-			),
+			],
 			// sp section.
-			array(
+			[
 				'section'     => 'sp',
 				'uid'         => 'sp_entityId',
 				'label'       => __( 'Entity Id (Required)', 'wp-saml-auth' ),
@@ -353,8 +358,8 @@ class WP_SAML_Auth_Settings {
 				'description' => __( 'SP (WordPress) entity identifier.', 'wp-saml-auth' ),
 				'default'     => 'urn:' . parse_url( home_url(), PHP_URL_HOST ),
 				'required'    => true,
-			),
-			array(
+			],
+			[
 				'section'     => 'sp',
 				'uid'         => 'sp_assertionConsumerService_url',
 				'label'       => __( 'Assertion Consumer Service URL (Required)', 'wp-saml-auth' ),
@@ -362,95 +367,95 @@ class WP_SAML_Auth_Settings {
 				'description' => __( 'URL where the response from the IdP should be returned (usually the login URL).', 'wp-saml-auth' ),
 				'default'     => home_url( '/wp-login.php' ),
 				'required'    => true,
-			),
+			],
 			// idp section.
-			array(
+			[
 				'section'     => 'idp',
 				'uid'         => 'idp_entityId',
 				'label'       => __( 'Entity Id (Required)', 'wp-saml-auth' ),
 				'type'        => 'text',
 				'description' => __( 'IdP entity identifier.', 'wp-saml-auth' ),
 				'required'    => true,
-			),
-			array(
+			],
+			[
 				'section'     => 'idp',
 				'uid'         => 'idp_singleSignOnService_url',
 				'label'       => __( 'Single SignOn Service URL (Required)', 'wp-saml-auth' ),
 				'type'        => 'url',
 				'description' => __( 'URL of the IdP where the SP (WordPress) will send the authentication request.', 'wp-saml-auth' ),
 				'required'    => true,
-			),
-			array(
+			],
+			[
 				'section'     => 'idp',
 				'uid'         => 'idp_singleLogoutService_url',
 				'label'       => __( 'Single Logout Service URL', 'wp-saml-auth' ),
 				'type'        => 'url',
 				'description' => __( 'URL of the IdP where the SP (WordPress) will send the signout request.', 'wp-saml-auth' ),
-			),
-			array(
+			],
+			[
 				'section'     => 'idp',
 				'uid'         => 'x509cert',
 				'label'       => __( 'x509 Cerificate Path', 'wp-saml-auth' ),
 				'type'        => 'text',
 				'description' => __( 'Path to the x509 certificate file, used for verifying the request.<br/>Include <code>ABSPATH</code> to set path base to WordPress\' ABSPATH constant.', 'wp-saml-auth' ),
-			),
-			array(
+			],
+			[
 				'section'     => 'idp',
 				'uid'         => 'certFingerprint',
 				'label'       => __( 'Certificate Fingerprint', 'wp-saml-auth' ),
 				'type'        => 'text',
 				'description' => __( 'If not using x509 certificate, paste the certificate fingerprint and specify the fingerprint algorithm below.', 'wp-saml-auth' ),
-			),
-			array(
+			],
+			[
 				'section' => 'idp',
 				'uid'     => 'certFingerprintAlgorithm',
 				'label'   => __( 'Certificate Fingerprint Algorithm', 'wp-saml-auth' ),
 				'type'    => 'select',
-				'choices' => array(
+				'choices' => [
 					''       => __( 'N/A', 'wp-saml-auth' ),
 					'sha1'   => 'sha1',
 					'sha256' => 'sha256',
 					'sha384' => 'sha384',
 					'sha512' => 'sha512',
-				),
-			),
+				],
+			],
 			// attributes section.
-			array(
+			[
 				'section' => 'attributes',
 				'uid'     => 'user_login_attribute',
 				'label'   => 'user_login',
 				'type'    => 'text',
 				'default' => 'uid',
-			),
-			array(
+			],
+			[
 				'section' => 'attributes',
 				'uid'     => 'user_email_attribute',
 				'label'   => 'user_email',
 				'type'    => 'text',
 				'default' => 'email',
-			),
-			array(
+			],
+			[
 				'section' => 'attributes',
 				'uid'     => 'display_name_attribute',
 				'label'   => 'display_name',
 				'type'    => 'text',
 				'default' => 'display_name',
-			),
-			array(
+			],
+			[
 				'section' => 'attributes',
 				'uid'     => 'first_name_attribute',
 				'label'   => 'first_name',
 				'type'    => 'text',
 				'default' => 'first_name',
-			),
-			array(
+			],
+			[
 				'section' => 'attributes',
 				'uid'     => 'last_name_attribute',
 				'label'   => 'last_name',
 				'type'    => 'text',
 				'default' => 'last_name',
-			),
-		);
+			],
+		];
 	}
 
 	/**

--- a/inc/class-wp-saml-auth.php
+++ b/inc/class-wp-saml-auth.php
@@ -40,8 +40,8 @@ class WP_SAML_Auth {
 	public static function get_instance() {
 		if ( ! isset( self::$instance ) ) {
 			self::$instance = new WP_SAML_Auth();
-			add_action( 'init', array( self::$instance, 'action_init' ) );
-			add_action( 'plugins_loaded', array( self::$instance, 'load_textdomain' ) );
+			add_action( 'init', [ self::$instance, 'action_init' ] );
+			add_action( 'plugins_loaded', [ self::$instance, 'load_textdomain' ] );
 		}
 		return self::$instance;
 	}
@@ -103,12 +103,12 @@ class WP_SAML_Auth {
 	 * Initialize the controller logic on the 'init' hook
 	 */
 	public function action_init() {
-		add_action( 'login_head', array( $this, 'action_login_head' ) );
-		add_action( 'login_message', array( $this, 'action_login_message' ) );
-		add_action( 'wp_logout', array( $this, 'action_wp_logout' ) );
-		add_filter( 'login_body_class', array( $this, 'filter_login_body_class' ) );
-		add_filter( 'authenticate', array( $this, 'filter_authenticate' ), 21, 3 ); // after wp_authenticate_username_password runs.
-		add_action( 'admin_notices', array( $this, 'action_admin_notices' ) );
+		add_action( 'login_head', [ $this, 'action_login_head' ] );
+		add_action( 'login_message', [ $this, 'action_login_message' ] );
+		add_action( 'wp_logout', [ $this, 'action_wp_logout' ] );
+		add_filter( 'login_body_class', [ $this, 'filter_login_body_class' ] );
+		add_filter( 'authenticate', [ $this, 'filter_authenticate' ], 21, 3 ); // after wp_authenticate_username_password runs.
+		add_action( 'admin_notices', [ $this, 'action_admin_notices' ] );
 	}
 
 	/**
@@ -147,15 +147,15 @@ class WP_SAML_Auth {
 		if ( ! self::get_option( 'permit_wp_login' ) || ! did_action( 'login_form_login' ) ) {
 			return $message;
 		}
-		$strings = array(
+		$strings = [
 			'title'     => __( 'Use one-click authentication:', 'wp-saml-auth' ),
 			'button'    => __( 'Sign In', 'wp-saml-auth' ),
 			'alt_title' => __( 'Or, sign in with WordPress:', 'wp-saml-auth' ),
-		);
+		];
 
-		$query_args  = array(
+		$query_args  = [
 			'action' => 'wp-saml-auth',
-		);
+		];
 		$redirect_to = filter_input( INPUT_GET, 'redirect_to', FILTER_SANITIZE_URL );
 		if ( $redirect_to ) {
 			$query_args['redirect_to'] = rawurlencode( $redirect_to );
@@ -187,11 +187,11 @@ class WP_SAML_Auth {
 			if ( empty( $internal_config['idp']['singleLogoutService']['url'] ) ) {
 				return;
 			}
-			$args = array(
-				'parameters'   => array(),
+			$args = [
+				'parameters'   => [],
 				'nameId'       => null,
 				'sessionIndex' => null,
-			);
+			];
 			/**
 			 * Permit the arguments passed to the logout() method to be customized.
 			 *
@@ -232,7 +232,7 @@ class WP_SAML_Auth {
 	 * @param string $password Password supplied by the user.
 	 * @return mixed
 	 */
-	public function filter_authenticate( $user, $username, $password ) {
+	public function filter_authenticate( $user, $username, $password ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 
 		$permit_wp_login = self::get_option( 'permit_wp_login' );
 		if ( is_a( $user, 'WP_User' ) && $permit_wp_login ) {
@@ -279,7 +279,7 @@ class WP_SAML_Auth {
 				}
 			} else {
 				$redirect_to = filter_input( INPUT_GET, 'redirect_to', FILTER_SANITIZE_URL );
-				$redirect_to = $redirect_to ? $redirect_to : $_SERVER['REQUEST_URI'];
+				$redirect_to = $redirect_to ? $redirect_to : ( isset( $_SERVER['REQUEST_URI'] ) ? sanitize_text_field( $_SERVER['REQUEST_URI'] ) : null );
 				/**
 				 * Allows forceAuthn="true" to be enabled.
 				 *
@@ -292,7 +292,7 @@ class WP_SAML_Auth {
 				 *
 				 * @param array $parameters
 				 */
-				$parameters = apply_filters( 'wp_saml_auth_login_parameters', array() );
+				$parameters = apply_filters( 'wp_saml_auth_login_parameters', [] );
 
 				$provider->login( $redirect_to, $parameters, $force_authn );
 			}
@@ -300,27 +300,27 @@ class WP_SAML_Auth {
 			$redirect_to = filter_input( INPUT_GET, 'redirect_to', FILTER_SANITIZE_URL );
 			if ( $redirect_to ) {
 				$redirect_to = add_query_arg(
-					array(
+					[
 						'redirect_to' => rawurlencode( $redirect_to ),
 						'action'      => 'wp-saml-auth',
-					),
+					],
 					wp_login_url()
 				);
 			} else {
 				$redirect_to = wp_login_url();
 				// Make sure we're only dealing with the URI components and not arguments.
-				$request = explode( '?', $_SERVER['REQUEST_URI'] );
+				$request = explode( '?', sanitize_text_field( $_SERVER['REQUEST_URI'] ) );
 				// Only persist redirect_to when it's not wp-login.php.
 				if ( false === stripos( $redirect_to, reset( $request ) ) ) {
-					$redirect_to = add_query_arg( 'redirect_to', $_SERVER['REQUEST_URI'], $redirect_to );
+					$redirect_to = add_query_arg( 'redirect_to', sanitize_text_field( $_SERVER['REQUEST_URI'] ), $redirect_to );
 				} else {
-					$redirect_to = add_query_arg( array( 'action' => 'wp-saml-auth' ), $redirect_to );
+					$redirect_to = add_query_arg( [ 'action' => 'wp-saml-auth' ], $redirect_to );
 				}
 			}
 			$provider->requireAuth(
-				array(
+				[
 					'ReturnTo' => $redirect_to,
-				)
+				]
 			);
 			$attributes = $provider->getAttributes();
 		} else {
@@ -374,8 +374,8 @@ class WP_SAML_Auth {
 			return new WP_Error( 'wp_saml_auth_auto_provision_disabled', esc_html__( 'No WordPress user exists for your account. Please contact your administrator.', 'wp-saml-auth' ) );
 		}
 
-		$user_args = array();
-		foreach ( array( 'display_name', 'user_login', 'user_email', 'first_name', 'last_name' ) as $type ) {
+		$user_args = [];
+		foreach ( [ 'display_name', 'user_login', 'user_email', 'first_name', 'last_name' ] as $type ) {
 			$attribute          = self::get_option( "{$type}_attribute" );
 			$user_args[ $type ] = ! empty( $attributes[ $attribute ][0] ) ? $attributes[ $attribute ][0] : '';
 		}

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
-<ruleset name="WordPress Coding Standards for Plugins">
-	<description>Generally-applicable sniffs for WordPress plugins</description>
+<ruleset name="WP SAML Auth Code Sniffs">
+	<description>Pantheon WordPress coding standards for WP SAML Auth</description>
 
 	<!-- Check all PHP files in directory tree by default. -->
 	<arg name="extensions" value="php"/>
@@ -9,17 +9,26 @@
 	<!-- Show sniff codes in all reports -->
 	<arg value="ps"/>
 
-	<rule ref="WordPress-Core" />
+	<rule ref="Pantheon-WP">
+		<!-- Ignore VIP rule about including files using custom constants. -->
+		<exclude name="WordPressVIPMinimum.Files.IncludingFile.UsingCustomConstant">
+			<file>*/inc/class-wp-saml-auth-cli.php</file>
+		</exclude>
+		<!-- Ignore Nonce verification checks for authentication requests -->
+		<exclude name="WordPress.Security.NonceVerification">
+			<file>*/inc/class-wp-saml-auth.php</file>
+		</exclude>
+		<!-- Ignore docblock rules for WP-CLI functions -->
+		<exclude name="Squiz.Commenting.FunctionComment.MissingParamTag">
+			<file>*/inc/class-wp-saml-auth-cli.php</file>
+		</exclude>
+	</rule>
 	<rule ref="WordPress-Docs" />
 	<rule ref="PHPCompatibility"/>
 
 	<!-- Minimum PHP and WP versions -->
-	<config name="testVersion" value="7.1-"/>
+	<config name="testVersion" value="7.3-"/>
 	<config name="minimum_supported_wp_version" value="4.4"/>
-
-	<rule ref="Squiz.Commenting.FunctionComment.MissingParamTag">
-		<exclude-pattern>*/inc/class-wp-saml-auth-cli.php</exclude-pattern>
-	</rule>
 
 	<exclude-pattern>*/bin/*</exclude-pattern>
 	<exclude-pattern>*/node_modules/*</exclude-pattern>

--- a/readme.txt
+++ b/readme.txt
@@ -275,6 +275,7 @@ Minimum supported PHP version is 7.3.
 
 = Latest =
 * Updates CONTRIBUTING.md [[#342](https://github.com/pantheon-systems/wp-saml-auth/pull/342)].
+* Bump dependencies [[#343](https://github.com/pantheon-systems/wp-saml-auth/pull/343)]
 
 = 2.1.3 (April 8, 2023) =
 * Fixes missing vendor/ directory in previous release [[#336](https://github.com/pantheon-systems/wp-saml-auth/pull/336)]

--- a/readme.txt
+++ b/readme.txt
@@ -273,11 +273,14 @@ Minimum supported PHP version is 7.3.
 
 == Changelog ==
 
+= Latest =
+* Updates CONTRIBUTING.md [[#342](https://github.com/pantheon-systems/wp-saml-auth/pull/342)].
+
 = 2.1.3 (April 8, 2023) =
 * Fixes missing vendor/ directory in previous release [[#336](https://github.com/pantheon-systems/wp-saml-auth/pull/336)]
 
 = 2.1.2 (April 7, 2023) =
-* Bump yoast/phpunit-polyfills from 1.0.4 to 1.0.5 [[#334](https://github.com/pantheon-systems/wp-saml-auth/pull/334)]
+* Bump yoast/phpunit-polyfills from 1.0.4 to 1.0.5 [[#334](https://github.com/pantheon-systems/wp-saml-auth/pull/334)].
 * Updates tested up to version
 * Removes unused NPM dependencies
 

--- a/wp-saml-auth.php
+++ b/wp-saml-auth.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: WP SAML Auth
- * Version: 2.1.3
+ * Version: 2.1.4-dev
  * Description: SAML authentication for WordPress, using SimpleSAMLphp.
  * Author: Pantheon
  * Author URI: https://pantheon.io

--- a/wp-saml-auth.php
+++ b/wp-saml-auth.php
@@ -19,7 +19,7 @@
  * @param string $option_name Configuration option name.
  */
 function wpsa_filter_option( $value, $option_name ) {
-	$defaults = array(
+	$defaults = [
 		/**
 		 * Type of SAML connection bridge to use.
 		 *
@@ -58,39 +58,39 @@ function wpsa_filter_option( $value, $option_name ) {
 		 *
 		 * @param array
 		 */
-		'internal_config'        => array(
+		'internal_config'        => [
 			// Validation of SAML responses is required.
 			'strict'  => true,
 			'debug'   => defined( 'WP_DEBUG' ) && WP_DEBUG ? true : false,
 			'baseurl' => home_url(),
-			'sp'      => array(
+			'sp'      => [
 				'entityId'                 => 'urn:' . parse_url( home_url(), PHP_URL_HOST ),
-				'assertionConsumerService' => array(
+				'assertionConsumerService' => [
 					'url'     => home_url(),
 					'binding' => 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST',
-				),
-			),
-			'idp'     => array(
+				],
+			],
+			'idp'     => [
 				// Required: Set based on provider's supplied value.
 				'entityId'                 => '',
-				'singleSignOnService'      => array(
+				'singleSignOnService'      => [
 					// Required: Set based on provider's supplied value.
 					'url'     => '',
 					'binding' => 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect',
-				),
-				'singleLogoutService'      => array(
+				],
+				'singleLogoutService'      => [
 					// Required: Set based on provider's supplied value.
 					'url'     => '',
 					'binding' => 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect',
-				),
+				],
 				// Required: Contents of the IDP's public x509 certificate.
 				// Use file_get_contents() to load certificate contents into scope.
 				'x509cert'                 => '',
 				// Optional: Instead of using the x509 cert, you can specify the fingerprint and algorithm.
 				'certFingerprint'          => '',
 				'certFingerprintAlgorithm' => '',
-			),
-		),
+			],
+		],
 		/**
 		 * Whether or not to automatically provision new WordPress users.
 		 *
@@ -153,7 +153,7 @@ function wpsa_filter_option( $value, $option_name ) {
 		 * @param string
 		 */
 		'default_role'           => get_option( 'default_role' ),
-	);
+	];
 	$value = isset( $defaults[ $option_name ] ) ? $defaults[ $option_name ] : $value;
 	return $value;
 }


### PR DESCRIPTION
To get out of the mess of squash merges and merge conflicts on these branches, I backed up and deleted the `develop` branch and force-pushed `master`'s history back to `develop`.

Develop pre-cleanup is backed up to https://github.com/pantheon-systems/wp-saml-auth/tree/develop-stash.
commits have been cherry-picked over to this PR branch, and I manually re-applied #342.

Also re-applies #339 #341 #343. 

Following this, we should be in better shape to work through development and releases as described in CONTRIBUTING.MD and modeled in https://github.com/pantheon-systems/plugin-pipeline-example.

This PR should rebased, not squashed or merged.