### PR TITLE
[CMSP-497] adding requestedAuthnContext as an option

### DIFF
--- a/inc/class-wp-saml-auth-options.php
+++ b/inc/class-wp-saml-auth-options.php
@@ -144,6 +144,9 @@ class WP_SAML_Auth_Options {
 					'certFingerprint'          => $options['certFingerprint'],
 					'certFingerprintAlgorithm' => $options['certFingerprintAlgorithm'],
 				),
+				'security' => array(
+					'requestedAuthnContext' => false,
+				)
 			),
 		);
 

--- a/wp-saml-auth.php
+++ b/wp-saml-auth.php
@@ -90,6 +90,9 @@ function wpsa_filter_option( $value, $option_name ) {
 				'certFingerprint'          => '',
 				'certFingerprintAlgorithm' => '',
 			),
+			'security' => array(
+				'requestedAuthnContext' => false,
+			)
 		),
 		/**
 		 * Whether or not to automatically provision new WordPress users.


### PR DESCRIPTION
Adding requestedAuthnContext as an option due to the following issue with Microsoft as an IDP:
https://learn.microsoft.com/en-us/troubleshoot/azure/active-directory/error-code-aadsts75011-auth-method-mismatch

