### PR TITLE
add a hook to modify returned attributes.

### DIFF
--- a/inc/class-wp-saml-auth.php
+++ b/inc/class-wp-saml-auth.php
@@ -363,10 +363,7 @@ class WP_SAML_Auth {
 		}
 
 		// Some SAML providers return oddly shaped responses.
-        $attributes = apply_filters( 
-            'wp_saml_auth_patch_attributes', $attributes,
-             $provider);
-
+		$attributes = apply_filters( 'wp_saml_auth_patch_attributes', $attributes, $provider );
 		$get_user_by = self::get_option( 'get_user_by' );
 		$attribute   = self::get_option( "user_{$get_user_by}_attribute" );
 		if ( empty( $attributes[ $attribute ][0] ) ) {

--- a/inc/class-wp-saml-auth.php
+++ b/inc/class-wp-saml-auth.php
@@ -362,8 +362,7 @@ class WP_SAML_Auth {
 			return new WP_Error( 'wp_saml_auth_no_attributes', esc_html__( 'No attributes were present in SAML response. Attributes are used to create and fetch users. Please contact your administrator', 'wp-saml-auth' ) );
 		}
 
-        // Some SAML providers return oddly shaped
-        // responses.
+		// Some SAML providers return oddly shaped responses.
         $attributes = apply_filters( 
             'wp_saml_auth_patch_attributes', $attributes,
              $provider);

--- a/inc/class-wp-saml-auth.php
+++ b/inc/class-wp-saml-auth.php
@@ -362,6 +362,12 @@ class WP_SAML_Auth {
 			return new WP_Error( 'wp_saml_auth_no_attributes', esc_html__( 'No attributes were present in SAML response. Attributes are used to create and fetch users. Please contact your administrator', 'wp-saml-auth' ) );
 		}
 
+        // Some SAML providers return oddly shaped
+        // responses.
+        $attributes = apply_filters( 
+            'wp_saml_auth_patch_attributes', $attributes,
+             $provider);
+
 		$get_user_by = self::get_option( 'get_user_by' );
 		$attribute   = self::get_option( "user_{$get_user_by}_attribute" );
 		if ( empty( $attributes[ $attribute ][0] ) ) {


### PR DESCRIPTION
Some SAML IdP's return non-standard SAML responses, for instance under some circumstances keyclock won't return a uid. Add a hook to allow attributes to be modified on the fly.