### PR TITLE
[jfdi] Add `phpcbf` before lint

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -1,6 +1,8 @@
 # On push, run the action-wporg-validator workflow.
 name: Lint and Test
 on: [push]
+permissions:
+  contents: write
 jobs:
   validate-readme-spacing:
     name: Validate README Spacing

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -7,14 +7,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - uses: pantheon-systems/validate-readme-spacing@v1
   wporg-validation:
     name: WP.org Validator
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: WP.org Validator
         uses: pantheon-systems/action-wporg-validator@1.0.0
         with:

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -19,6 +19,14 @@ jobs:
         uses: pantheon-systems/action-wporg-validator@1.0.0
         with:
           type: plugin
+  composer-install:
+    name: Composer Install
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Composer Install
+        run: composer install
   lint:
     name: Lint
     runs-on: ubuntu-latest
@@ -26,6 +34,4 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Lint
-        run: |
-          composer install
-          composer lint
+        run: composer lint

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -1,8 +1,6 @@
 # On push, run the action-wporg-validator workflow.
 name: Lint and Test
 on: [push]
-permissions:
-  contents: write
 jobs:
   validate-readme-spacing:
     name: Validate README Spacing

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -27,16 +27,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Install Composer dependencies
-        run: composer install
-      - name: PHP Code Beautifier
-        run: composer phpcbf
-      - name: Commit changes
-        run: |
-          git config --global user.name "Pantheon Robot"
-          git config --global user.email "bot@getpantheon.io"
-          git add -A
-          git commit -m "Apply PHP Code Beautifier changes" || true # Allow commit to fail if there are no changes.
-          git push || true # Allow push to fail if there are no changes.
-      - name: Lint
-        run: composer lint
+      - uses: shalior/wordpress-phpcs-action@v1
+        with:
+          github_token: ${{ github.token }}
+          use_default_configuration_file: true
+      - uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "PHPCBF: Fix coding standards"
+          commit_options: '--no-verify'
+          branch: ${{ github.ref }}
+          commit_user_name: "Pantheon Robot"
+          commit_user_email: "bot@getpantheon.io"

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -27,6 +27,21 @@ jobs:
         uses: actions/checkout@v4
       - name: Composer Install
         run: composer install
+  phpcbf:
+    name: PHP Code Beautifier
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: PHP Code Beautifier
+        run: composer phpcbf
+      - name: Commit changes
+        run: |
+          git config --global user.name "Pantheon Robot"
+          git config --global user.email "bot@getpantheon.io"
+          git add -A
+          git commit -m "Apply PHP Code Beautifier changes"
+          git push
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -36,7 +36,7 @@ jobs:
           git config --global user.name "Pantheon Robot"
           git config --global user.email "bot@getpantheon.io"
           git add -A
-          git commit -m "Apply PHP Code Beautifier changes"
+          git commit -m "Apply PHP Code Beautifier changes" || true # Allow commit to fail if there are no changes.
           git push || true # Allow push to fail if there are no changes.
       - name: Lint
         run: composer lint

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -27,20 +27,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - uses: shalior/wordpress-phpcs-action@v1
-        with:
-          github_token: ${{ github.token }}
-          use_default_configuration_file: true
-      - name: Install Composer dependencies
-        run: composer install
-      - name: PHP Code Beautifier
-        run: composer phpcbf
-      - uses: stefanzweifel/git-auto-commit-action@v5
-        with:
-          commit_message: "PHPCBF: Fix coding standards"
-          commit_options: '--no-verify'
-          branch: ${{ github.ref }}
-          commit_user_name: "Pantheon Robot"
-          commit_user_email: "bot@getpantheon.io"
       - name: Lint
-        run: composer lint
+        run: |
+          composer install
+          composer lint

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -31,6 +31,10 @@ jobs:
         with:
           github_token: ${{ github.token }}
           use_default_configuration_file: true
+      - name: Install Composer dependencies
+        run: composer install
+      - name: PHP Code Beautifier
+        run: composer phpcbf
       - uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: "PHPCBF: Fix coding standards"
@@ -38,3 +42,5 @@ jobs:
           branch: ${{ github.ref }}
           commit_user_name: "Pantheon Robot"
           commit_user_email: "bot@getpantheon.io"
+      - name: Lint
+        run: composer lint

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -21,20 +21,14 @@ jobs:
         uses: pantheon-systems/action-wporg-validator@1.0.0
         with:
           type: plugin
-  composer-install:
-    name: Composer Install
+  lint:
+    name: Lint
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Composer Install
+      - name: Install Composer dependencies
         run: composer install
-  phpcbf:
-    name: PHP Code Beautifier
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
       - name: PHP Code Beautifier
         run: composer phpcbf
       - name: Commit changes
@@ -43,12 +37,6 @@ jobs:
           git config --global user.email "bot@getpantheon.io"
           git add -A
           git commit -m "Apply PHP Code Beautifier changes"
-          git push
-  lint:
-    name: Lint
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+          git push || true # Allow push to fail if there are no changes.
       - name: Lint
         run: composer lint

--- a/.github/workflows/phpcbf.yml
+++ b/.github/workflows/phpcbf.yml
@@ -14,13 +14,14 @@ jobs:
         run: |
           composer install
           composer phpcbf || true # Allow the workflow to continue even if PHPCBF fails
-      - uses: stefanzweifel/git-auto-commit-action@v5
+      - name: Commit changes to PR
         id: git-auto-commit
-        with:
-          commit_message: "PHPCBF: Fix coding standards"
-          commit_options: '--no-verify'
-          commit_user_name: "Pantheon Robot"
-          commit_user_email: "bot@getpantheon.io"
+        run: |
+          git config --global user.email "bot@getpantheon.com"
+          git config --global user.name "Pantheon Robot"
+          git add .
+          git diff-index --quiet HEAD || git commit -m "PHPCBF: Fix coding standards" --no-verify
+          echo ::set-output name=changes_detected::$(git diff-index --quiet HEAD || echo "true")
       - name: Add PR Comment
         if: steps.git-auto-commit.outputs.changes_detected == 'true'
         env:

--- a/.github/workflows/phpcbf.yml
+++ b/.github/workflows/phpcbf.yml
@@ -10,6 +10,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
       - name: Install Composer dependencies and run PHPCBF
         run: |
           composer install
@@ -23,7 +25,7 @@ jobs:
           if [ "$DIFF" == "true" ]; then
             git add .
             git commit -m "PHPCBF: Fix coding standards" --no-verify
-            git push origin ${{ github.head_ref}}
+            git push origin ${{ github.event.pull_request.head.ref }}
             echo "changes_detected=true" >> $GITHUB_ENV
           else
             echo "changes_detected=false" >> $GITHUB_ENV

--- a/.github/workflows/phpcbf.yml
+++ b/.github/workflows/phpcbf.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Install Composer dependencies and run PHPCBF
         run: |
           composer install
-          composer phpcbf
+          composer phpcbf || true # Allow the workflow to continue even if PHPCBF fails
       - uses: stefanzweifel/git-auto-commit-action@v5
         id: git-auto-commit
         with:

--- a/.github/workflows/phpcbf.yml
+++ b/.github/workflows/phpcbf.yml
@@ -19,11 +19,17 @@ jobs:
         run: |
           git config --global user.email "bot@getpantheon.com"
           git config --global user.name "Pantheon Robot"
-          git add .
-          git diff-index --quiet HEAD || git commit -m "PHPCBF: Fix coding standards" --no-verify
-          echo ::set-output name=changes_detected::$(git diff-index --quiet HEAD || echo "true")
+          DIFF=$(git diff-index --quiet HEAD || echo "true")
+          if [ "$DIFF" == "true" ]; then
+            git add .
+            git commit -m "PHPCBF: Fix coding standards" --no-verify
+            git push origin HEAD
+            echo "changes_detected=true" >> $GITHUB_ENV
+          else
+            echo "changes_detected=false" >> $GITHUB_ENV
+          fi
       - name: Add PR Comment
-        if: steps.git-auto-commit.outputs.changes_detected == 'true'
+        if: env.changes_detected == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/.github/workflows/phpcbf.yml
+++ b/.github/workflows/phpcbf.yml
@@ -23,7 +23,7 @@ jobs:
           if [ "$DIFF" == "true" ]; then
             git add .
             git commit -m "PHPCBF: Fix coding standards" --no-verify
-            git push origin HEAD
+            git push origin ${{ github.head_ref}}
             echo "changes_detected=true" >> $GITHUB_ENV
           else
             echo "changes_detected=false" >> $GITHUB_ENV

--- a/.github/workflows/phpcbf.yml
+++ b/.github/workflows/phpcbf.yml
@@ -19,7 +19,6 @@ jobs:
         with:
           commit_message: "PHPCBF: Fix coding standards"
           commit_options: '--no-verify'
-          branch: ${{ github.ref }}
           commit_user_name: "Pantheon Robot"
           commit_user_email: "bot@getpantheon.io"
       - name: Add PR Comment

--- a/.github/workflows/phpcbf.yml
+++ b/.github/workflows/phpcbf.yml
@@ -1,0 +1,23 @@
+name: PHP Code Beautifier
+on: [pull_request]
+permissions:
+  contents: write
+  pull-requests: write
+jobs:
+  phpcbf:
+    name: PHPCBF & Commit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install Composer dependencies and run PHPCBF
+        run: |
+          composer install
+          composer phpcbf
+      - uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "PHPCBF: Fix coding standards"
+          commit_options: '--no-verify'
+          branch: ${{ github.ref }}
+          commit_user_name: "Pantheon Robot"
+          commit_user_email: "bot@getpantheon.io"

--- a/.github/workflows/phpcbf.yml
+++ b/.github/workflows/phpcbf.yml
@@ -15,9 +15,17 @@ jobs:
           composer install
           composer phpcbf
       - uses: stefanzweifel/git-auto-commit-action@v5
+        id: git-auto-commit
         with:
           commit_message: "PHPCBF: Fix coding standards"
           commit_options: '--no-verify'
           branch: ${{ github.ref }}
           commit_user_name: "Pantheon Robot"
           commit_user_email: "bot@getpantheon.io"
+      - name: Add PR Comment
+        if: steps.git-auto-commit.outputs.changes_detected == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          CURRENT_COMMIT=$(git rev-parse --short HEAD)
+          gh pr comment ${{ github.event.pull_request.number }} -b "Hi from your friendly robot! :robot: I fixed PHPCS issues with \`phpcbf\` on $CURRENT_COMMIT. Please review the changes."

--- a/inc/class-wp-saml-auth.php
+++ b/inc/class-wp-saml-auth.php
@@ -235,7 +235,7 @@ class WP_SAML_Auth {
 	public function filter_authenticate( $user, $username, $password ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable,Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
 
 		$permit_wp_login = self::get_option( 'permit_wp_login' );
-		if ( is_a( $user, 'WP_User' ) ) {
+		if (is_a( $user, 'WP_User' )) {
 
 			if ( ! $permit_wp_login ) {
 				$user = $this->do_saml_authentication();

--- a/inc/class-wp-saml-auth.php
+++ b/inc/class-wp-saml-auth.php
@@ -237,7 +237,7 @@ class WP_SAML_Auth {
 		$permit_wp_login = self::get_option( 'permit_wp_login' );
 		if (is_a( $user, 'WP_User' )) {
 
-			if ( ! $permit_wp_login ) {
+			if (!$permit_wp_login) {
 				$user = $this->do_saml_authentication();
 			}
 

--- a/inc/class-wp-saml-auth.php
+++ b/inc/class-wp-saml-auth.php
@@ -235,9 +235,9 @@ class WP_SAML_Auth {
 	public function filter_authenticate( $user, $username, $password ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable,Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
 
 		$permit_wp_login = self::get_option( 'permit_wp_login' );
-		if (is_a( $user, 'WP_User' )) {
+		if ( is_a( $user, 'WP_User' ) ) {
 
-			if (!$permit_wp_login) {
+			if ( ! $permit_wp_login ) {
 				$user = $this->do_saml_authentication();
 			}
 


### PR DESCRIPTION
This PR adds a `phpcbf` step before the linting to commit anything that `cbf` could fix before running the linter. This makes it so things like [this](https://github.com/pantheon-systems/wp-saml-auth/actions/runs/9993678387/job/27621618086?pr=379) don't block being able to merge PRs.