### PR TITLE
add `jazzsequence/action-validate-plugin-version`

### DIFF
--- a/.github/workflows/validate-plugin-tested-up-to-version.yml
+++ b/.github/workflows/validate-plugin-tested-up-to-version.yml
@@ -1,0 +1,19 @@
+name: Validate Tested Up To Version
+on:
+  schedule:
+    - cron: '0 0 * * 0'
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  validate-plugin-version:
+    runs-on: ubuntu-latest
+    name: Validate Plugin Tested Up To
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: jazzsequence/action-validate-plugin-version@v1
+        branch: 'master'

--- a/.github/workflows/validate-plugin-tested-up-to-version.yml
+++ b/.github/workflows/validate-plugin-tested-up-to-version.yml
@@ -16,4 +16,4 @@ jobs:
         with:
           fetch-depth: 0
       - uses: jazzsequence/action-validate-plugin-version@v1
-        branch: 'master'
+        branch: 'develop'


### PR DESCRIPTION
This PR adds [`jazzsequence/action-validate-plugin-version`](https://github.com/jazzsequence/action-validate-plugin-version) to automatically bump the Tested Up To version.