### PR TITLE
Phpcbf variable interpolation

### DIFF
--- a/.github/workflows/phpcbf.yml
+++ b/.github/workflows/phpcbf.yml
@@ -18,6 +18,8 @@ jobs:
           composer phpcbf || true # Allow the workflow to continue even if PHPCBF fails
       - name: Commit changes to PR
         id: git-auto-commit
+        env:
+          PR_BRANCH: ${{ github.event.pull_request.head.ref }}
         run: |
           git config --global user.email "bot@getpantheon.com"
           git config --global user.name "Pantheon Robot"
@@ -25,7 +27,7 @@ jobs:
           if [ "$DIFF" == "true" ]; then
             git add .
             git commit -m "PHPCBF: Fix coding standards" --no-verify
-            git push origin ${{ github.event.pull_request.head.ref }}
+            git push origin "${PR_BRANCH}"
             echo "changes_detected=true" >> $GITHUB_ENV
           else
             echo "changes_detected=false" >> $GITHUB_ENV

--- a/wp-saml-auth.php
+++ b/wp-saml-auth.php
@@ -15,8 +15,8 @@
 /**
  * Bootstrap the WP SAML Auth plugin.
  */
-function wpsa_boostrap()    {
-	if ( ! defined('WP_SAML_AUTH_AUTOLOADER' ) ) {
+function wpsa_boostrap() {
+	if ( ! defined( 'WP_SAML_AUTH_AUTOLOADER' ) ) {
 		define( 'WP_SAML_AUTH_AUTOLOADER', __DIR__ . '/vendor/autoload.php' );
 	}
 

--- a/wp-saml-auth.php
+++ b/wp-saml-auth.php
@@ -15,8 +15,8 @@
 /**
  * Bootstrap the WP SAML Auth plugin.
  */
-function wpsa_boostrap() {
-	if ( ! defined( 'WP_SAML_AUTH_AUTOLOADER' ) ) {
+function wpsa_boostrap()    {
+	if ( ! defined('WP_SAML_AUTH_AUTOLOADER' ) ) {
 		define( 'WP_SAML_AUTH_AUTOLOADER', __DIR__ . '/vendor/autoload.php' );
 	}
 


### PR DESCRIPTION
Address security concerns with using `${{ github.event.pull_request.head.ref }}` within the run step

```
Using variable interpolation `${{...}}` with `github` context data in a `run:` step could allow an attacker to inject their own code into the runner.
```