### PR TITLE
[SITE-4994] Don't run SSP tests for the internal backend

### DIFF
--- a/inc/class-wp-saml-auth.php
+++ b/inc/class-wp-saml-auth.php
@@ -716,85 +716,64 @@ class WP_SAML_Auth {
 					]
 				);
 			}
-		} else {
-			// Get the SimpleSAMLphp version and status.
-			$simplesamlphp_version = $this->get_simplesamlphp_version();
-			$simplesamlphp_version_status = $this->check_simplesamlphp_version( $simplesamlphp_version );
+			return;
+		}
+		// Get the SimpleSAMLphp version and status.
+		$simplesamlphp_version = $this->get_simplesamlphp_version();
+		$simplesamlphp_version_status = $this->check_simplesamlphp_version( $simplesamlphp_version );
 
-			// If we don't have a SimpleSAMLphp version but the connection type is set, we haven't set up SimpleSAMLphp correctly.
-			if ( ! $simplesamlphp_version && $connection_type === 'simplesaml' ) {
-				// Only show this notice if we're on the settings page.
-				if ( ! isset( $_GET['page'] ) || $_GET['page'] !== 'wp-saml-auth-settings' ) {
-					return;
-				}
+		// If we don't have a SimpleSAMLphp version but the connection type is set, we haven't set up SimpleSAMLphp correctly.
+		if ( ! $simplesamlphp_version && $connection_type === 'simplesaml' ) {
+			// Only show this notice if we're on the settings page.
+			if ( ! isset( $_GET['page'] ) || $_GET['page'] !== 'wp-saml-auth-settings' ) {
+				return;
+			}
+			wp_admin_notice(
+				sprintf(
+					// Translators: %s is the link to the plugin page.
+					__( 'SimpleSAMLphp is defined as the SAML connection type, but the SimpleSAMLphp library was not found. Visit the <a href="%s">plugin page</a> for more information', 'wp-saml-auth' ),
+					$plugin_page
+				),
+				[
+					'type' => 'error',
+					'dismissible' => true,
+					'attributes' => [
+						'data-slug' => 'wp-saml-auth',
+						'data-type' => 'simplesamlphp-not-found',
+					],
+				]
+			);
+		}
+
+		// Check SimpleSAMLphp version.
+		if ( $simplesamlphp_version !== false ) {
+			if ( 'critical' === $simplesamlphp_version_status ) {
+				$min_version = self::get_option( 'critical_simplesamlphp_version' );
 				wp_admin_notice(
 					sprintf(
-						// Translators: %s is the link to the plugin page.
-						__( 'SimpleSAMLphp is defined as the SAML connection type, but the SimpleSAMLphp library was not found. Visit the <a href="%s">plugin page</a> for more information', 'wp-saml-auth' ),
-						$plugin_page
+						// Translators: 1 is the installed version of SimpleSAMLphp, 2 is the minimum version and 3 is the most secure version.
+						__( '<strong>Security Alert:</strong> The SimpleSAMLphp version used by the WP SAML Auth plugin (%1$s) has a critical security vulnerability (CVE-2023-26881). Please update to version %2$s or later. <a href="%3$s">Learn more</a>.', 'wp-saml-auth' ),
+						esc_html( $simplesamlphp_version ),
+						esc_html( $min_version ),
+						esc_url( admin_url( 'options-general.php?page=wp-saml-auth-settings' ) )
 					),
 					[
 						'type' => 'error',
-						'dismissible' => true,
+						'dismissible' => false,
 						'attributes' => [
 							'data-slug' => 'wp-saml-auth',
-							'data-type' => 'simplesamlphp-not-found',
+							'data-type' => 'simplesamlphp-critical-vulnerability',
 						],
 					]
 				);
-			}
-
-			// Check SimpleSAMLphp version.
-			if ( $simplesamlphp_version !== false ) {
-				if ( 'critical' === $simplesamlphp_version_status ) {
-					$min_version = self::get_option( 'critical_simplesamlphp_version' );
-					wp_admin_notice(
-						sprintf(
-							// Translators: 1 is the installed version of SimpleSAMLphp, 2 is the minimum version and 3 is the most secure version.
-							__( '<strong>Security Alert:</strong> The SimpleSAMLphp version used by the WP SAML Auth plugin (%1$s) has a critical security vulnerability (CVE-2023-26881). Please update to version %2$s or later. <a href="%3$s">Learn more</a>.', 'wp-saml-auth' ),
-							esc_html( $simplesamlphp_version ),
-							esc_html( $min_version ),
-							esc_url( admin_url( 'options-general.php?page=wp-saml-auth-settings' ) )
-						),
-						[
-							'type' => 'error',
-							'dismissible' => false,
-							'attributes' => [
-								'data-slug' => 'wp-saml-auth',
-								'data-type' => 'simplesamlphp-critical-vulnerability',
-							],
-						]
-					);
-				} elseif ( 'warning' === $simplesamlphp_version_status ) {
-					$min_version = self::get_option( 'min_simplesamlphp_version' );
-					wp_admin_notice(
-						sprintf(
-							// Translators: 1 is the installed version of SimpleSAMLphp, 2 is the minimum version and 3 is the most secure version.
-							__( '<strong>Security Recommendation:</strong> The  SimpleSAMLphp version used by the WP SAML Auth plugin (%1$s) is older than the recommended secure version. Please consider updating to version %2$s or later. <a href="%3$s">Learn more</a>.', 'wp-saml-auth' ),
-							esc_html( $simplesamlphp_version ),
-							esc_html( $min_version ),
-							esc_url( admin_url( 'options-general.php?page=wp-saml-auth-settings' ) )
-						),
-						[
-							'type' => 'warning',
-							'dismissible' => true,
-							'attributes' => [
-								'data-slug' => 'wp-saml-auth',
-								'data-type' => 'simplesamlphp-version-warning',
-							],
-						]
-					);
-				}
-			} elseif ( 'unknown' === $simplesamlphp_version_status ) {
-				// Only show this notice if we're on the settings page.
-				if ( ! isset( $_GET['page'] ) || $_GET['page'] !== 'wp-saml-auth-settings' ) {
-					return;
-				}
+			} elseif ( 'warning' === $simplesamlphp_version_status ) {
+				$min_version = self::get_option( 'min_simplesamlphp_version' );
 				wp_admin_notice(
 					sprintf(
-						// Translators: 1 is the minimum recommended version of SimpleSAMLphp. 2 is a link to the WP SAML Auth settings page.
-						__( '<strong>Warning:</strong> WP SAML Auth was unable to determine your SimpleSAMLphp version. Please ensure you are using version %1$s or later for security. <a href="%2$s">Learn more</a>.', 'wp-saml-auth' ),
-						esc_html( self::get_option( 'min_simplesamlphp_version' ) ),
+						// Translators: 1 is the installed version of SimpleSAMLphp, 2 is the minimum version and 3 is the most secure version.
+						__( '<strong>Security Recommendation:</strong> The  SimpleSAMLphp version used by the WP SAML Auth plugin (%1$s) is older than the recommended secure version. Please consider updating to version %2$s or later. <a href="%3$s">Learn more</a>.', 'wp-saml-auth' ),
+						esc_html( $simplesamlphp_version ),
+						esc_html( $min_version ),
 						esc_url( admin_url( 'options-general.php?page=wp-saml-auth-settings' ) )
 					),
 					[
@@ -802,11 +781,32 @@ class WP_SAML_Auth {
 						'dismissible' => true,
 						'attributes' => [
 							'data-slug' => 'wp-saml-auth',
-							'data-type' => 'simplesamlphp-version-unknown',
+							'data-type' => 'simplesamlphp-version-warning',
 						],
 					]
 				);
 			}
+		} elseif ( 'unknown' === $simplesamlphp_version_status ) {
+			// Only show this notice if we're on the settings page.
+			if ( ! isset( $_GET['page'] ) || $_GET['page'] !== 'wp-saml-auth-settings' ) {
+				return;
+			}
+			wp_admin_notice(
+				sprintf(
+					// Translators: 1 is the minimum recommended version of SimpleSAMLphp. 2 is a link to the WP SAML Auth settings page.
+					__( '<strong>Warning:</strong> WP SAML Auth was unable to determine your SimpleSAMLphp version. Please ensure you are using version %1$s or later for security. <a href="%2$s">Learn more</a>.', 'wp-saml-auth' ),
+					esc_html( self::get_option( 'min_simplesamlphp_version' ) ),
+					esc_url( admin_url( 'options-general.php?page=wp-saml-auth-settings' ) )
+				),
+				[
+					'type' => 'warning',
+					'dismissible' => true,
+					'attributes' => [
+						'data-slug' => 'wp-saml-auth',
+						'data-type' => 'simplesamlphp-version-unknown',
+					],
+				]
+			);
 		}
 	}
 


### PR DESCRIPTION
When the connection_type is set to `internal`, the SimpleSAMLphp tests should not be run in `action_admin_notices()`.
Fixes #412

(Note that the diff looks more complicated due to the whitespace changes resulting from the different indentation).