### PR TITLE
check for SimpleSAML\Auth\Simple object before finding its autoloader

### DIFF
--- a/inc/class-wp-saml-auth.php
+++ b/inc/class-wp-saml-auth.php
@@ -108,7 +108,7 @@ class WP_SAML_Auth {
 				}
 			}
 
-			// test again in case `require_once $simplesamlphp_autoloader` didn't work.
+			// test again in case `require_once $simplesamlphp_autoloader` didn't find it.
 			if ( ! class_exists( $this->simplesamlphp_class ) ) {
 				$this->maybeLogError();
 				return;

--- a/inc/class-wp-saml-auth.php
+++ b/inc/class-wp-saml-auth.php
@@ -92,33 +92,51 @@ class WP_SAML_Auth {
 			$auth_config    = self::get_option( 'internal_config' );
 			$this->provider = new OneLogin\Saml2\Auth( $auth_config );
 		} else {
-			$simplesamlphp_autoloader = self::get_simplesamlphp_autoloader();
+      $this->simplesamlphp_class = 'SimpleSAML\Auth\Simple';
+      
+      // if object doesn't exist, find the autoloader
+      if ( ! class_exists( $this->simplesamlphp_class ) ) {
+        $simplesamlphp_autoloader = self::get_simplesamlphp_autoloader();
+        
+        // If the autoloader exists, load it.
+        if (!empty($simplesamlphp_autoloader) && file_exists($simplesamlphp_autoloader)) {
+          require_once $simplesamlphp_autoloader;
+        } else {
+          // Autoloader not found.
+          $this->maybeLogError($simplesamlphp_autoloader);
+          return;
+        }
+      }
 
-			// If the autoloader exists, load it.
-			if ( ! empty( $simplesamlphp_autoloader ) && file_exists( $simplesamlphp_autoloader ) ) {
-				require_once $simplesamlphp_autoloader;
-			} else {
-				// Autoloader not found.
-				if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-					$error_message = sprintf(
-						// Translators: %s is the path to the SimpleSAMLphp autoloader file (if found).
-						__( 'WP SAML Auth: SimpleSAMLphp autoloader could not be loaded for set_provider. Path determined: %s', 'wp-saml-auth' ),
-						empty( $simplesamlphp_autoloader ) ? '[empty]' : esc_html( $simplesamlphp_autoloader )
-					);
-					error_log( $error_message );
-				}
-				return;
-			}
-
-			if ( class_exists( 'SimpleSAML\Auth\Simple' ) ) {
-				$this->simplesamlphp_class = 'SimpleSAML\Auth\Simple';
-			}
+      // test again in case `require_once $simplesamlphp_autoloader` didn't work.
 			if ( ! class_exists( $this->simplesamlphp_class ) ) {
+        $this->maybeLogError();
 				return;
 			}
+   
 			$this->provider = new $this->simplesamlphp_class( self::get_option( 'auth_source' ) );
 		}
 	}
+  
+  /**
+   * Use error_log when WP_DEBUG is set
+   *
+   * @param string $path Path to autoloader
+   * @return void
+   */
+  protected function maybeLogError( $path = '' ) {
+    if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+      $error_message = empty( $path )
+        ? __( 'WP SAML Auth: SimpleSAMLphp autoloader could not be loaded for set_provider.', 'wp-saml-auth')
+        : sprintf(
+          // Translators: %s is the path to the SimpleSAMLphp autoloader file (if found).
+          __( 'WP SAML Auth: SimpleSAMLphp autoloader could not be loaded for set_provider. Path determined: %s', 'wp-saml-auth'),
+          esc_html($path)
+        );
+      
+      error_log($error_message);
+    }
+  }
 
 	/**
 	 * Initialize the controller logic on the 'init' hook

--- a/inc/class-wp-saml-auth.php
+++ b/inc/class-wp-saml-auth.php
@@ -92,25 +92,25 @@ class WP_SAML_Auth {
 			$auth_config    = self::get_option( 'internal_config' );
 			$this->provider = new OneLogin\Saml2\Auth( $auth_config );
 		} else {
-      $this->simplesamlphp_class = 'SimpleSAML\Auth\Simple';
-      
-      // if object doesn't exist, find the autoloader
-      if ( ! class_exists( $this->simplesamlphp_class ) ) {
-        $simplesamlphp_autoloader = self::get_simplesamlphp_autoloader();
-        
-        // If the autoloader exists, load it.
-        if (!empty($simplesamlphp_autoloader) && file_exists($simplesamlphp_autoloader)) {
-          require_once $simplesamlphp_autoloader;
-        } else {
-          // Autoloader not found.
-          $this->maybeLogError($simplesamlphp_autoloader);
-          return;
-        }
-      }
-
-      // test again in case `require_once $simplesamlphp_autoloader` didn't work.
+			$this->simplesamlphp_class = 'SimpleSAML\Auth\Simple';
+			
+			// if object doesn't exist, find the autoloader
 			if ( ! class_exists( $this->simplesamlphp_class ) ) {
-        $this->maybeLogError();
+				$simplesamlphp_autoloader = self::get_simplesamlphp_autoloader();
+
+				// If the autoloader exists, load it.
+				if (!empty($simplesamlphp_autoloader) && file_exists($simplesamlphp_autoloader)) {
+					require_once $simplesamlphp_autoloader;
+				} else {
+					// Autoloader not found.
+					$this->maybeLogError($simplesamlphp_autoloader);
+					return;
+				}
+			}
+
+			// test again in case `require_once $simplesamlphp_autoloader` didn't work.
+			if ( ! class_exists( $this->simplesamlphp_class ) ) {
+				$this->maybeLogError();
 				return;
 			}
    
@@ -118,25 +118,25 @@ class WP_SAML_Auth {
 		}
 	}
   
-  /**
-   * Use error_log when WP_DEBUG is set
-   *
-   * @param string $path Path to autoloader
-   * @return void
-   */
-  protected function maybeLogError( $path = '' ) {
-    if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-      $error_message = empty( $path )
-        ? __( 'WP SAML Auth: SimpleSAMLphp autoloader could not be loaded for set_provider.', 'wp-saml-auth')
-        : sprintf(
-          // Translators: %s is the path to the SimpleSAMLphp autoloader file (if found).
-          __( 'WP SAML Auth: SimpleSAMLphp autoloader could not be loaded for set_provider. Path determined: %s', 'wp-saml-auth'),
-          esc_html($path)
-        );
-      
-      error_log($error_message);
-    }
-  }
+	/**
+	 * Use error_log when WP_DEBUG is set
+	 *
+	 * @param string $path Path to autoloader
+	 * @return void
+	 */
+	protected function maybeLogError( $path = '' ) {
+		if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+			$error_message = empty( $path )
+				? __( 'WP SAML Auth: SimpleSAMLphp autoloader could not be loaded for set_provider.', 'wp-saml-auth')
+				: sprintf(
+					// Translators: %s is the path to the SimpleSAMLphp autoloader file (if found).
+					__( 'WP SAML Auth: SimpleSAMLphp autoloader could not be loaded for set_provider. Path determined: %s', 'wp-saml-auth'),
+					esc_html($path)
+				);
+
+			error_log($error_message);
+		}
+	}
 
 	/**
 	 * Initialize the controller logic on the 'init' hook


### PR DESCRIPTION
Prior to 2.2.0, we were relying the Composer autoloader to load the `SimpleSAML\Auth\Simple` object.  But, we also had a bug in our code that meant when the plugin searched for an autoloader, it woudln't find it.  That bug was hidden for years, but with 2.2.0 and the addition of a call to `log_error` when `WP_DEBUG` is set revealed it to us.  

This PR checks for the existence of the object _prior_ to looking for an autoloader.  If the object exists, likely due to the Composer autoloader, then the plugin simply uses it without looking for a different loader.  But, if it doesn't exist, then it'll fall back on the original login within 2.2.0.