### PR TITLE
Pre release

### DIFF
--- a/.github/workflows/build-tag-release.yml
+++ b/.github/workflows/build-tag-release.yml
@@ -16,9 +16,10 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
     - name: Build, tag, and release
-      uses: pantheon-systems/plugin-release-actions/build-tag-release@prerelease
+      uses: pantheon-systems/plugin-release-actions/build-tag-release@main
       with:
         gh_token: ${{ secrets.GITHUB_TOKEN }}
         build_composer_assets: "true"
         generate_release_notes: "true"
         draft: "true"
+        main_plugin_file: wp-saml-auth.php

--- a/.github/workflows/build-tag-release.yml
+++ b/.github/workflows/build-tag-release.yml
@@ -22,4 +22,3 @@ jobs:
         build_composer_assets: "true"
         generate_release_notes: "true"
         draft: "true"
-        main_plugin_file: wp-saml-auth.php

--- a/.github/workflows/tag-prerelease.yml
+++ b/.github/workflows/tag-prerelease.yml
@@ -24,3 +24,4 @@ jobs:
         generate_release_notes: "true"
         draft: "true"
         prerelease: "true"
+        main_plugin_file: wp-saml-auth.php

--- a/.github/workflows/tag-prerelease.yml
+++ b/.github/workflows/tag-prerelease.yml
@@ -2,7 +2,8 @@ name: Build, Tag, and Release
 on:
   push:
     branches:
-      - 'master'
+      - 'develop'
+      - 'pre-release'
 
 permissions:
   pull-requests: write
@@ -22,3 +23,4 @@ jobs:
         build_composer_assets: "true"
         generate_release_notes: "true"
         draft: "true"
+        prerelease: "true"

--- a/.github/workflows/wordpress-plugin-deploy.yml
+++ b/.github/workflows/wordpress-plugin-deploy.yml
@@ -1,7 +1,7 @@
 name: Release wp-saml-auth plugin to wp.org
 on:
   release:
-    types: [published]
+    types: [released]
 
 jobs:
   release:


### PR DESCRIPTION
Update WordPress plugin deploy trigger to avoid running release action on prereleases.