### PR TITLE
Don't run wp.org pipeline on prereleases

### DIFF
--- a/.github/workflows/wordpress-plugin-deploy.yml
+++ b/.github/workflows/wordpress-plugin-deploy.yml
@@ -1,7 +1,7 @@
 name: Release wp-saml-auth plugin to wp.org
 on:
   release:
-    types: [published]
+    types: [released]
 
 jobs:
   release:


### PR DESCRIPTION
PR'd directly to `master` to avoid triggering "on release" when prereleases are published from draft.