### PR TITLE
ci: Pin GitHub Actions to commit SHAs (DELENG-235)

### DIFF
--- a/.github/workflows/build-tag-release.yml
+++ b/.github/workflows/build-tag-release.yml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
     - name: Build, tag, and release
-      uses: pantheon-systems/plugin-release-actions/build-tag-release@main
+      uses: pantheon-systems/plugin-release-actions/build-tag-release@a3839d25efa9d0d4270c088702c2072a2e49edde # main 2025-11-07T23:23:14Z
       with:
         gh_token: ${{ secrets.GITHUB_TOKEN }}
         build_composer_assets: "true"

--- a/.github/workflows/composer-diff.yml
+++ b/.github/workflows/composer-diff.yml
@@ -12,13 +12,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
       - name: Generate composer diff
         id: composer_diff
-        uses: IonBazan/composer-diff-action@v1
-      - uses: marocchino/sticky-pull-request-comment@v2
+        uses: IonBazan/composer-diff-action@3140157575f6a67799cc80248ae35f5fb303ab15 # v1.2.0
+      - uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
         if: ${{ steps.composer_diff.outputs.composer_diff_exit_code != 0 }}
         with:
           header: composer-diff

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -7,16 +7,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
-      - uses: pantheon-systems/validate-readme-spacing@v1
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: pantheon-systems/validate-readme-spacing@229ea162621009cf8e09bf2beba405017150130e # v1.0.5
   wporg-validation:
     name: WP.org Validator
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: WP.org Validator
-        uses: pantheon-systems/action-wporg-validator@1.0.0
+        uses: pantheon-systems/action-wporg-validator@4df6286ef133ca95bbc955728fc649322e433380 # 1.0.0 2023-06-09T19:59:09Z
         with:
           type: plugin
   lint:
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Lint
         run: |
           composer install
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Run ShellCheck
         run: |
           shellcheck --version

--- a/.github/workflows/phpcbf.yml
+++ b/.github/workflows/phpcbf.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ github.event.pull_request.head.ref }}
       - name: Install Composer dependencies and run PHPCBF

--- a/.github/workflows/validate-plugin-tested-up-to-version.yml
+++ b/.github/workflows/validate-plugin-tested-up-to-version.yml
@@ -12,8 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     name: Validate Plugin Tested Up To
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
-      - uses: jazzsequence/action-validate-plugin-version@v1
+      - uses: jazzsequence/action-validate-plugin-version@9cb142a9e858cac795ce7ca32f07f49a2874dba2 # v1.2.8
         branch: 'develop'

--- a/.github/workflows/wordpress-plugin-deploy.yml
+++ b/.github/workflows/wordpress-plugin-deploy.yml
@@ -7,9 +7,9 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
     - name: WordPress Plugin Deploy
-      uses: 10up/action-wordpress-plugin-deploy@2.3.0
+      uses: 10up/action-wordpress-plugin-deploy@54bd289b8525fd23a5c365ec369185f2966529c2 # 2.3.0 2025-01-21T15:30:29Z
       env:
         SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
         SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}


### PR DESCRIPTION
Automated pinning of GitHub Actions to their commit SHAs.

This improves security by preventing supply chain attacks through compromised action tags.
Each action is pinned to its current commit SHA with a comment showing the original version.

## Related Ticket
https://getpantheon.atlassian.net/browse/DELENG-235

## Need Help?
If you have questions or need help, ask in Slack [#ask-delivery-engineering](https://pantheon.enterprise.slack.com/archives/C09SPT0A65B)