### PR TITLE
[SITE-5624] Add SAML replay attack protection via InResponseTo validation

### DIFF
--- a/inc/class-wp-saml-auth.php
+++ b/inc/class-wp-saml-auth.php
@@ -336,7 +336,10 @@ class WP_SAML_Auth {
 		$provider = $this->get_provider();
 		if ( is_a( $provider, 'OneLogin\Saml2\Auth' ) ) {
 			if ( ! empty( $_POST['SAMLResponse'] ) ) {
-				$provider->processResponse();
+				// Retrieve the stored request ID for InResponseTo validation.
+				$request_id = $this->get_saml_request_id();
+				$provider->processResponse( $request_id );
+				$this->clear_saml_request_id();
 				if ( ! $provider->isAuthenticated() ) {
 					// Translators: Includes error reason from OneLogin.
 					return new WP_Error( 'wp_saml_auth_unauthenticated', sprintf( __( 'User is not authenticated with SAML IdP. Reason: %s', 'wp-saml-auth' ), $provider->getLastErrorReason() ) );
@@ -376,7 +379,13 @@ class WP_SAML_Auth {
 				 */
 				$parameters = apply_filters( 'wp_saml_auth_login_parameters', [] );
 
-				$provider->login( $redirect_to, $parameters, $force_authn );
+				// Use $stay=true to prevent exit, so we can store the request ID.
+				$sso_url = $provider->login( $redirect_to, $parameters, $force_authn, false, true );
+				$this->save_saml_request_id( $provider->getLastRequestID() );
+				header( 'Pragma: no-cache' );
+				header( 'Cache-Control: no-cache, must-revalidate' );
+				header( 'Location: ' . $sso_url );
+				exit();
 			}
 		} elseif ( is_a( $provider, $this->simplesamlphp_class ) ) {
 			$redirect_to = filter_input( INPUT_GET, 'redirect_to', FILTER_SANITIZE_URL );
@@ -898,5 +907,45 @@ class WP_SAML_Auth {
 	 */
 	public function load_textdomain() {
 		load_plugin_textdomain( 'wp-saml-auth', false, dirname( plugin_basename( __FILE__ ), 2 ) . '/languages' );
+	}
+
+	/**
+	 * Save the SAML AuthnRequest ID for InResponseTo validation.
+	 *
+	 * Stores the request ID as a short-lived transient and sets a cookie
+	 * to tie the transient to this specific login attempt.
+	 *
+	 * @param string $request_id The AuthnRequest ID.
+	 */
+	private function save_saml_request_id( $request_id ) {
+		$nonce = wp_generate_password( 12, false );
+		$key   = 'wp_saml_auth_req_' . $nonce;
+		set_transient( $key, $request_id, 5 * MINUTE_IN_SECONDS );
+		setcookie( 'wp_saml_auth_nonce', $nonce, time() + 5 * MINUTE_IN_SECONDS, COOKIEPATH, COOKIE_DOMAIN, is_ssl(), true );
+	}
+
+	/**
+	 * Retrieve the stored SAML AuthnRequest ID.
+	 *
+	 * @return string|null The stored request ID, or null if not found.
+	 */
+	private function get_saml_request_id() {
+		if ( empty( $_COOKIE['wp_saml_auth_nonce'] ) ) {
+			return null;
+		}
+		$key        = 'wp_saml_auth_req_' . sanitize_key( $_COOKIE['wp_saml_auth_nonce'] );
+		$request_id = get_transient( $key );
+		return $request_id ? $request_id : null;
+	}
+
+	/**
+	 * Clear the stored SAML AuthnRequest ID after use.
+	 */
+	private function clear_saml_request_id() {
+		if ( ! empty( $_COOKIE['wp_saml_auth_nonce'] ) ) {
+			$key = 'wp_saml_auth_req_' . sanitize_key( $_COOKIE['wp_saml_auth_nonce'] );
+			delete_transient( $key );
+			setcookie( 'wp_saml_auth_nonce', '', time() - 3600, COOKIEPATH, COOKIE_DOMAIN, is_ssl(), true );
+		}
 	}
 }

--- a/wp-saml-auth.php
+++ b/wp-saml-auth.php
@@ -89,17 +89,20 @@ function wpsa_filter_option( $value, $option_name ) {
 		 */
 		'internal_config'        => [
 			// Validation of SAML responses is required.
-			'strict'  => true,
-			'debug'   => defined( 'WP_DEBUG' ) && WP_DEBUG ? true : false,
-			'baseurl' => home_url(),
-			'sp'      => [
+			'strict'   => true,
+			'debug'    => defined( 'WP_DEBUG' ) && WP_DEBUG ? true : false,
+			'baseurl'  => home_url(),
+			'security' => [
+				'rejectUnsolicitedResponsesWithInResponseTo' => true,
+			],
+			'sp'       => [
 				'entityId'                 => 'urn:' . parse_url( home_url(), PHP_URL_HOST ),
 				'assertionConsumerService' => [
 					'url'     => home_url(),
 					'binding' => 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST',
 				],
 			],
-			'idp'     => [
+			'idp'      => [
 				// Required: Set based on provider's supplied value.
 				'entityId'                 => '',
 				'singleSignOnService'      => [


### PR DESCRIPTION
> **This is a Claude Code-generated PR. I (Anais) have NOT reviewed this code yet. This PR will remain in draft until I do a proper review. Do not merge.**

## Context

This is a quick PR to have some history and a starting point for addressing a SAML replay attack vulnerability reported by a customer. This will need thorough testing and a full review before it can be considered for merge.

- Jira: https://getpantheon.atlassian.net/browse/SITE-5624
- WordPress.org support thread: https://wordpress.org/support/topic/saml-replay-attack/

## What is a SAML replay attack?

An attacker captures a valid SAML login response (the signed XML that proves "this user authenticated successfully") and re-submits it to the Service Provider (WordPress) to log in as that user. If the SP doesn't track which responses it has already seen or verify that the response matches a request it actually sent, the replayed response is accepted as valid -- within the `NotOnOrAfter` time window set by the IdP.

## What this PR does

1. **InResponseTo validation**: When the plugin initiates a login, it now stores the AuthnRequest ID (via a transient + cookie) and passes it to `processResponse($requestId)`. The OneLogin library then verifies the SAML response's `InResponseTo` attribute matches the request we sent.

2. **Reject unsolicited responses with InResponseTo**: Enables `rejectUnsolicitedResponsesWithInResponseTo` in the default security config, so responses claiming to answer a request we never sent are rejected.

## What I'm confident in (verified by reading code)

- The plugin currently does NOT pass a `requestId` to `processResponse()` (`class-wp-saml-auth.php:339`) -- so InResponseTo is never validated
- The OneLogin library fully supports this: `processResponse($requestId = null)` (`Auth.php:228`)
- `rejectUnsolicitedResponsesWithInResponseTo` defaults to `false` in OneLogin (`Settings.php:405`)
- There is no replay cache or assertion ID tracking anywhere in the plugin

## What needs verification (not tested)

- **IdP-initiated logins may break.** If users log in by clicking an app tile on their IdP portal (e.g., Okta/Azure dashboard) rather than visiting `wp-login.php` first, there is no prior AuthnRequest, so no stored request ID. With `rejectUnsolicitedResponsesWithInResponseTo = true`, these logins would be rejected. This is the biggest risk and needs careful consideration.
- **`$stay=true` flow change.** The original `login()` call let OneLogin handle the redirect and `exit()`. This PR changes it to use `$stay=true` so we can capture the request ID before redirecting ourselves. This changes the control flow and needs testing.
- **Transient + cookie storage on Pantheon.** Transients hit the database on every login attempt, and cookies may interact with edge caching. Needs validation in Pantheon environments.
- **SimpleSAMLphp code path.** Only the OneLogin (`internal` connection type) path is addressed. The SimpleSAMLphp path may need similar treatment.
- **Concurrent logins.** The cookie-based approach should handle multiple users logging in simultaneously, but this needs testing.