### PR TITLE
Prepare 2.3.3-dev

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,6 +58,6 @@ Behat requires a Pantheon site. Once you've created the site, you'll need [insta
     * `git checkout -b release-XYZ-dev`
     * `git push origin release-XYZ-dev`
     * Create a pull request on GitHub UI from `release-XYZ-dev` to `main` to trigger all required status checks
-    * _Wait for all required status checks to pass in CI. Once all tests pass, push to main from the terminal:_
+    * _Wait for all required status checks to pass in CI and for the PR to be approved. Once all tests pass and you have approval, push to main from the terminal:_
     * `git checkout main && git push origin main`
     * _Note: While main is typically protected, having an open PR with passing tests allows direct push to main, which is the preferred method here._

--- a/README.md
+++ b/README.md
@@ -407,6 +407,8 @@ Minimum supported PHP version is 7.3.
 ## Changelog ##
 
 ### 2.3.2 (15 May 2026) ###
+* Update dependencies [[#477](https://github.com/pantheon-systems/wp-saml-auth/pull/477)].
+
 
 ### 2.3.1 (March 6, 2026) ###
 * Adds `wp_saml_auth_auto_add_to_blog` filter to control whether auto-provisioned users are added to sites in multisite environments [[#465](https://github.com/pantheon-systems/wp-saml-auth/pull/465)].

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 **Requires at least:** 6.4  
 **Tested up to:** 6.9  
 **Requires PHP:** 7.4  
-**Stable tag:** 2.3.3-dev
+**Stable tag:** 2.3.3-dev  
 **License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 **Requires at least:** 6.4  
 **Tested up to:** 6.9  
 **Requires PHP:** 7.4  
-**Stable tag:** 2.3.2-dev  
+**Stable tag:** 2.3.2  
 **License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -406,7 +406,7 @@ Minimum supported PHP version is 7.3.
 
 ## Changelog ##
 
-### 2.3.2-dev ###
+### 2.3.2 (15 May 2026) ###
 
 ### 2.3.1 (March 6, 2026) ###
 * Adds `wp_saml_auth_auto_add_to_blog` filter to control whether auto-provisioned users are added to sites in multisite environments [[#465](https://github.com/pantheon-systems/wp-saml-auth/pull/465)].

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 **Requires at least:** 6.4  
 **Tested up to:** 6.9  
 **Requires PHP:** 7.4  
-**Stable tag:** 2.3.2  
+**Stable tag:** 2.3.3-dev
 **License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -406,9 +406,10 @@ Minimum supported PHP version is 7.3.
 
 ## Changelog ##
 
+### 2.3.3-dev ###
+
 ### 2.3.2 (15 May 2026) ###
 * Update dependencies [[#477](https://github.com/pantheon-systems/wp-saml-auth/pull/477)].
-
 
 ### 2.3.1 (March 6, 2026) ###
 * Adds `wp_saml_auth_auto_add_to_blog` filter to control whether auto-provisioned users are added to sites in multisite environments [[#465](https://github.com/pantheon-systems/wp-saml-auth/pull/465)].

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: authentication, SAML
 Requires at least: 6.4
 Tested up to: 6.9
 Requires PHP: 7.4
-Stable tag: 2.3.2-dev
+Stable tag: 2.3.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -398,7 +398,7 @@ Minimum supported PHP version is 7.3.
 
 == Changelog ==
 
-= 2.3.2-dev =
+= 2.3.2 (15 May 2026) =
 
 = 2.3.1 (March 6, 2026) =
 * Adds `wp_saml_auth_auto_add_to_blog` filter to control whether auto-provisioned users are added to sites in multisite environments [[#465](https://github.com/pantheon-systems/wp-saml-auth/pull/465)].

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: authentication, SAML
 Requires at least: 6.4
 Tested up to: 6.9
 Requires PHP: 7.4
-Stable tag: 2.3.2
+Stable tag: 2.3.3-dev
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -397,6 +397,8 @@ Minimum supported PHP version is 7.3.
 
 
 == Changelog ==
+
+= 2.3.3-dev =
 
 = 2.3.2 (15 May 2026) =
 * Update dependencies [[#477](https://github.com/pantheon-systems/wp-saml-auth/pull/477)].

--- a/readme.txt
+++ b/readme.txt
@@ -399,6 +399,7 @@ Minimum supported PHP version is 7.3.
 == Changelog ==
 
 = 2.3.2 (15 May 2026) =
+* Update dependencies [[#477](https://github.com/pantheon-systems/wp-saml-auth/pull/477)].
 
 = 2.3.1 (March 6, 2026) =
 * Adds `wp_saml_auth_auto_add_to_blog` filter to control whether auto-provisioned users are added to sites in multisite environments [[#465](https://github.com/pantheon-systems/wp-saml-auth/pull/465)].

--- a/wp-saml-auth.php
+++ b/wp-saml-auth.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: WP SAML Auth
- * Version: 2.3.2-dev
+ * Version: 2.3.2
  * Description: SAML authentication for WordPress, using SimpleSAMLphp.
  * Author: Pantheon
  * Author URI: https://pantheon.io

--- a/wp-saml-auth.php
+++ b/wp-saml-auth.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: WP SAML Auth
- * Version: 2.3.2
+ * Version: 2.3.3-dev
  * Description: SAML authentication for WordPress, using SimpleSAMLphp.
  * Author: Pantheon
  * Author URI: https://pantheon.io


### PR DESCRIPTION
## Summary

Post-release branch reconciliation and version bump for next development cycle.

- Rebase main onto release to sync branches after 2.3.2 release
- Bump version to 2.3.3-dev in README.md, readme.txt, wp-saml-auth.php
- Add 2.3.3-dev changelog heading
- Clean up extra blank line from release action in changelog