### PR TITLE
Prepare 2.3.3-dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,6 +407,8 @@ Minimum supported PHP version is 7.3.
 ## Changelog ##
 
 ### 2.3.2 (15 May 2026) ###
+* Update dependencies [[#477](https://github.com/pantheon-systems/wp-saml-auth/pull/477)].
+
 
 ### 2.3.1 (March 6, 2026) ###
 * Adds `wp_saml_auth_auto_add_to_blog` filter to control whether auto-provisioned users are added to sites in multisite environments [[#465](https://github.com/pantheon-systems/wp-saml-auth/pull/465)].

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 **Requires at least:** 6.4  
 **Tested up to:** 6.9  
 **Requires PHP:** 7.4  
-**Stable tag:** 2.3.2-dev  
+**Stable tag:** 2.3.2  
 **License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -406,7 +406,7 @@ Minimum supported PHP version is 7.3.
 
 ## Changelog ##
 
-### 2.3.2-dev ###
+### 2.3.2 (15 May 2026) ###
 
 ### 2.3.1 (March 6, 2026) ###
 * Adds `wp_saml_auth_auto_add_to_blog` filter to control whether auto-provisioned users are added to sites in multisite environments [[#465](https://github.com/pantheon-systems/wp-saml-auth/pull/465)].

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 **Requires at least:** 6.4  
 **Tested up to:** 6.9  
 **Requires PHP:** 7.4  
-**Stable tag:** 2.3.2  
+**Stable tag:** 2.3.3-dev  
 **License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -405,6 +405,8 @@ WP SAML Auth 2.2.0 requires WordPress version 6.4 or later.
 Minimum supported PHP version is 7.3.
 
 ## Changelog ##
+
+### 2.3.3-dev ###
 
 ### 2.3.2 (15 May 2026) ###
 * Update dependencies [[#477](https://github.com/pantheon-systems/wp-saml-auth/pull/477)].

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: authentication, SAML
 Requires at least: 6.4
 Tested up to: 6.9
 Requires PHP: 7.4
-Stable tag: 2.3.2-dev
+Stable tag: 2.3.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -398,7 +398,7 @@ Minimum supported PHP version is 7.3.
 
 == Changelog ==
 
-= 2.3.2-dev =
+= 2.3.2 (15 May 2026) =
 
 = 2.3.1 (March 6, 2026) =
 * Adds `wp_saml_auth_auto_add_to_blog` filter to control whether auto-provisioned users are added to sites in multisite environments [[#465](https://github.com/pantheon-systems/wp-saml-auth/pull/465)].

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: authentication, SAML
 Requires at least: 6.4
 Tested up to: 6.9
 Requires PHP: 7.4
-Stable tag: 2.3.2
+Stable tag: 2.3.3-dev
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -397,6 +397,8 @@ Minimum supported PHP version is 7.3.
 
 
 == Changelog ==
+
+= 2.3.3-dev =
 
 = 2.3.2 (15 May 2026) =
 * Update dependencies [[#477](https://github.com/pantheon-systems/wp-saml-auth/pull/477)].

--- a/readme.txt
+++ b/readme.txt
@@ -399,6 +399,7 @@ Minimum supported PHP version is 7.3.
 == Changelog ==
 
 = 2.3.2 (15 May 2026) =
+* Update dependencies [[#477](https://github.com/pantheon-systems/wp-saml-auth/pull/477)].
 
 = 2.3.1 (March 6, 2026) =
 * Adds `wp_saml_auth_auto_add_to_blog` filter to control whether auto-provisioned users are added to sites in multisite environments [[#465](https://github.com/pantheon-systems/wp-saml-auth/pull/465)].

--- a/wp-saml-auth.php
+++ b/wp-saml-auth.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: WP SAML Auth
- * Version: 2.3.2-dev
+ * Version: 2.3.2
  * Description: SAML authentication for WordPress, using SimpleSAMLphp.
  * Author: Pantheon
  * Author URI: https://pantheon.io

--- a/wp-saml-auth.php
+++ b/wp-saml-auth.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: WP SAML Auth
- * Version: 2.3.2
+ * Version: 2.3.3-dev
  * Description: SAML authentication for WordPress, using SimpleSAMLphp.
  * Author: Pantheon
  * Author URI: https://pantheon.io


### PR DESCRIPTION
## Summary
- Bump version from 2.3.2 to 2.3.3-dev in wp-saml-auth.php, readme.txt, and README.md
- Add 2.3.3-dev changelog heading

Post-release step per [CONTRIBUTING.md](https://github.com/pantheon-systems/wp-saml-auth/blob/main/CONTRIBUTING.md#release-process). Once CI passes and approved, push to main from terminal.