### PR TITLE
Add pull_request trigger to lint-test workflow

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -1,6 +1,6 @@
 # On push, run the action-wporg-validator workflow.
 name: Lint and Test
-on: [push]
+on: [push, pull_request]
 jobs:
   validate-readme-spacing:
     name: Validate README Spacing

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -1,6 +1,10 @@
 # On push, run the action-wporg-validator workflow.
 name: Lint and Test
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 jobs:
   validate-readme-spacing:
     name: Validate README Spacing


### PR DESCRIPTION
## Summary

- lint-test.yml only triggered on `push` (all branches), meaning lint and tests ran after merge but not on PRs
- Narrowed `push` to `main` only, added `pull_request` trigger so tests run before merge
- `push` is restricted to `main` to avoid duplicate CI runs: without this, pushing to a PR branch fires both `push` and `pull_request` events simultaneously, running the same tests twice

## Why

Ensure tests run on PRs so failures are caught before merge. This also mitigates the GitHub 60-day inactivity issue: if nightly CI gets silently disabled on a quiet repo, PR-triggered tests still catch problems before they land on main.

Part of [SITE-6011](https://getpantheon.atlassian.net/browse/SITE-6011).

[SITE-6011]: https://getpantheon.atlassian.net/browse/SITE-6011?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ