### PR TITLE
fix(VUL-25719): bump wp-coding-standards/wpcs from 3.3.0 to 3.4.1

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -977,7 +977,7 @@
                     "homepage": "https://github.com/Nyholm"
                 },
                 {
-                    "name": "Márk Sági-Kazár",
+                    "name": "M\u00e1rk S\u00e1gi-Kaz\u00e1r",
                     "email": "mark.sagikazar@gmail.com",
                     "homepage": "https://github.com/sagikazarmark"
                 },
@@ -1161,7 +1161,7 @@
                     "homepage": "https://github.com/Nyholm"
                 },
                 {
-                    "name": "Márk Sági-Kazár",
+                    "name": "M\u00e1rk S\u00e1gi-Kaz\u00e1r",
                     "email": "mark.sagikazar@gmail.com",
                     "homepage": "https://github.com/sagikazarmark"
                 },
@@ -1780,21 +1780,21 @@
         },
         {
             "name": "phpcsstandards/phpcsextra",
-            "version": "1.5.0",
+            "version": "1.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHPCSExtra.git",
-                "reference": "b598aa890815b8df16363271b659d73280129101"
+                "reference": "39467533fdb742446d68c1d10ac33d625ee0311c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSExtra/zipball/b598aa890815b8df16363271b659d73280129101",
-                "reference": "b598aa890815b8df16363271b659d73280129101",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSExtra/zipball/39467533fdb742446d68c1d10ac33d625ee0311c",
+                "reference": "39467533fdb742446d68c1d10ac33d625ee0311c",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.4",
-                "phpcsstandards/phpcsutils": "^1.2.0",
+                "phpcsstandards/phpcsutils": "^1.2.3",
                 "squizlabs/php_codesniffer": "^3.13.5 || ^4.0.1"
             },
             "require-dev": {
@@ -1858,20 +1858,20 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-11-12T23:06:57+00:00"
+            "time": "2026-07-27T11:13:17+00:00"
         },
         {
             "name": "phpcsstandards/phpcsutils",
-            "version": "1.2.2",
+            "version": "1.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHPCSUtils.git",
-                "reference": "c216317e96c8b3f5932808f9b0f1f7a14e3bbf55"
+                "reference": "5f35d9408c54d7b529501f3c688b6eae562aea1f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/c216317e96c8b3f5932808f9b0f1f7a14e3bbf55",
-                "reference": "c216317e96c8b3f5932808f9b0f1f7a14e3bbf55",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/5f35d9408c54d7b529501f3c688b6eae562aea1f",
+                "reference": "5f35d9408c54d7b529501f3c688b6eae562aea1f",
                 "shasum": ""
             },
             "require": {
@@ -1951,7 +1951,7 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-12-08T14:27:58+00:00"
+            "time": "2026-07-27T10:28:41+00:00"
         },
         {
             "name": "phpstan/phpdoc-parser",
@@ -4180,7 +4180,7 @@
                     "email": "fabien@symfony.com"
                 },
                 {
-                    "name": "Jean-François Simon",
+                    "name": "Jean-Fran\u00e7ois Simon",
                     "email": "jeanfrancois.simon@sensiolabs.com"
                 },
                 {
@@ -5796,27 +5796,27 @@
         },
         {
             "name": "wp-coding-standards/wpcs",
-            "version": "3.3.0",
+            "version": "3.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
-                "reference": "7795ec6fa05663d716a549d0b44e47ffc8b0d4a6"
+                "reference": "ec2ff942335f33683a5957a85d138753876a05cf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/7795ec6fa05663d716a549d0b44e47ffc8b0d4a6",
-                "reference": "7795ec6fa05663d716a549d0b44e47ffc8b0d4a6",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/ec2ff942335f33683a5957a85d138753876a05cf",
+                "reference": "ec2ff942335f33683a5957a85d138753876a05cf",
                 "shasum": ""
             },
             "require": {
+                "php": ">=7.2",
                 "ext-filter": "*",
                 "ext-libxml": "*",
                 "ext-tokenizer": "*",
                 "ext-xmlreader": "*",
-                "php": ">=7.2",
-                "phpcsstandards/phpcsextra": "^1.5.0",
-                "phpcsstandards/phpcsutils": "^1.1.0",
-                "squizlabs/php_codesniffer": "^3.13.4"
+                "squizlabs/php_codesniffer": "^3.13.5",
+                "phpcsstandards/phpcsutils": "^1.2.3",
+                "phpcsstandards/phpcsextra": "^1.5.1"
             },
             "require-dev": {
                 "php-parallel-lint/php-console-highlighter": "^1.0.0",
@@ -5858,7 +5858,7 @@
                     "type": "custom"
                 }
             ],
-            "time": "2025-11-25T12:08:04+00:00"
+            "time": "2026-07-27T11:15:00+00:00"
         },
         {
             "name": "yoast/phpunit-polyfills",


### PR DESCRIPTION
## Summary

Bumps `wp-coding-standards/wpcs` from 3.3.0 to 3.4.1 to resolve CVE-2026-45293 (arbitrary code execution in WordPress Coding Standards). Also updates two transitive dependencies that wpcs 3.4.1 requires at higher minimum versions.

Addresses: [VUL-25719](https://getpantheon.atlassian.net/browse/VUL-25719)

## CVEs

| Package | CVE | Severity | Description | Fixed In |
|---|---|---|---|---|
| wp-coding-standards/wpcs | [CVE-2026-45293](https://nvd.nist.gov/vuln/detail/CVE-2026-45293) | High | Arbitrary code execution vulnerability in WordPress Coding Standards (WordPressCS) | 3.4.1 |

## Changes

- **composer.lock only** — `wp-coding-standards/wpcs` is a transitive dependency (pulled in by `pantheon-systems/pantheon-wp-coding-standards` and `automattic/vipwpcs`). It is not listed in `composer.json`, so only the lockfile is updated.
- `wp-coding-standards/wpcs`: 3.3.0 → 3.4.1
- `phpcsstandards/phpcsextra`: 1.5.0 → 1.5.1 (required by wpcs 3.4.1: `^1.5.1`)
- `phpcsstandards/phpcsutils`: 1.2.2 → 1.2.3 (required by wpcs 3.4.1: `^1.2.3` and phpcsextra 1.5.1: `^1.2.3`)

## Risk assessment

**Low** — lockfile-only patch/minor bump into a dev-only coding standards tool (used exclusively by the `lint` CI job). `wp-coding-standards/wpcs` is a phpcodesniffer-standard type package; it is not imported at runtime by the plugin itself and cannot affect plugin behavior in production.

| Layer | Score | Evidence |
|---|---|---|
| Pre-merge detection | strong | 7 PHP test files, behat and phpunit suites; lint + behat jobs run on PRs |
| Deployment safety | unknown | deploy config lives in WordPress.org pipeline; no staging layer visible in repo |
| Production detection | unknown | WordPress plugin — observability config not in repo |
| Recovery speed | partial | release-please present; 3 releases in last ~14 months |

Bump: `wp-coding-standards/wpcs` 3.3.0 → 3.4.1 (minor); transitive deps patch.

[VUL-25719]: https://getpantheon.atlassian.net/browse/VUL-25719?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ