### PR TITLE
SITE-6023 Fix/saml auth collation bypass

### DIFF
--- a/.github/workflows/behat-tests.yml
+++ b/.github/workflows/behat-tests.yml
@@ -121,7 +121,7 @@ jobs:
       - name: SSH agent
         uses: webfactory/ssh-agent@v0.9.1
         with:
-          ssh-private-key: ${{ secrets.SITE_OWNER_SSH_PRIVATE_KEY }}
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
           log-public-key: true
 
       - name: Configure SSH (no strict host key checking)

--- a/.github/workflows/behat-tests.yml
+++ b/.github/workflows/behat-tests.yml
@@ -121,7 +121,7 @@ jobs:
       - name: SSH agent
         uses: webfactory/ssh-agent@v0.9.1
         with:
-          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+          ssh-private-key: ${{ secrets.SITE_OWNER_SSH_PRIVATE_KEY }}
           log-public-key: true
 
       - name: Configure SSH (no strict host key checking)

--- a/.github/workflows/validate-plugin-tested-up-to-version.yml
+++ b/.github/workflows/validate-plugin-tested-up-to-version.yml
@@ -16,4 +16,5 @@ jobs:
         with:
           fetch-depth: 0
       - uses: jazzsequence/action-validate-plugin-version@v2
-        branch: 'main'
+        with:
+          branch: 'main'

--- a/bin/behat-prepare.sh
+++ b/bin/behat-prepare.sh
@@ -166,6 +166,15 @@ cat > "$PREPARE_DIR/private/simplesamlphp/config/authsources.php" <<EOF
         'eduPersonAffiliation' => 'employee',
         'mail' => '${WORDPRESS_ADMIN_EMAIL}',
     ],
+    // SITE-6023: attacker whose asserted email is an accented variant of the
+    // seeded victim (collationvictim@example.com). An accent-insensitive DB
+    // collation makes get_user_by() match the victim; the plugin must reject
+    // this near-match rather than authenticate as the victim.
+    'collationattacker:collationattackerpass' => [
+        'uid' => 'collationattacker',
+        'eduPersonAffiliation' => 'employee',
+        'mail' => 'coll\xc3\xa1tionvictim@example.com',
+    ],
 ];
 
 // Prevent global attributes from being auto-injected
@@ -252,6 +261,11 @@ terminus wp "$SITE_ENV" -- option update home "https://$PANTHEON_SITE_URL"
 terminus wp "$SITE_ENV" -- option update siteurl "https://$PANTHEON_SITE_URL"
 terminus wp "$SITE_ENV" -- plugin activate wp-native-php-sessions wp-saml-auth
 terminus wp "$SITE_ENV" -- theme activate "$TERMINUS_SITE"
+# SITE-6023: seed a victim whose email is the unaccented form of the
+# collationattacker IdP account's asserted email. The account-takeover Behat
+# scenario logs in as the attacker and asserts the login is rejected rather
+# than authenticated as this victim.
+terminus wp "$SITE_ENV" -- user create collationvictim collationvictim@example.com --role=administrator --user_pass=collationvictimpass
 terminus wp "$SITE_ENV" -- rewrite structure '/%year%/%monthnum%/%day%/%postname%/'
 # Create writeable directories in /files (aka wp-content/uploads) that SimpleSAMLphp might need.
 terminus wp "$SITE_ENV" -- eval '

--- a/bin/behat-prepare.sh
+++ b/bin/behat-prepare.sh
@@ -173,7 +173,7 @@ cat > "$PREPARE_DIR/private/simplesamlphp/config/authsources.php" <<EOF
     'collationattacker:collationattackerpass' => [
         'uid' => 'collationattacker',
         'eduPersonAffiliation' => 'employee',
-        'mail' => 'coll\xc3\xa1tionvictim@example.com',
+        'mail' => 'collátionvictim@example.com',
     ],
 ];
 

--- a/bin/behat-prepare.sh
+++ b/bin/behat-prepare.sh
@@ -166,10 +166,17 @@ cat > "$PREPARE_DIR/private/simplesamlphp/config/authsources.php" <<EOF
         'eduPersonAffiliation' => 'employee',
         'mail' => '${WORDPRESS_ADMIN_EMAIL}',
     ],
-    // SITE-6023: attacker whose asserted email is an accented variant of the
-    // seeded victim (collationvictim@example.com). An accent-insensitive DB
-    // collation makes get_user_by() match the victim; the plugin must reject
-    // this near-match rather than authenticate as the victim.
+    // SITE-6023: a legitimate victim who auto-provisions via SAML, and an
+    // attacker whose asserted email is an accented variant of the victim's.
+    // An accent-insensitive DB collation makes get_user_by() match the victim,
+    // so the plugin must reject the attacker's near-match rather than
+    // authenticate as the victim. The Behat scenario provisions the victim
+    // first, then asserts the attacker login is rejected.
+    'collationvictim:collationvictimpass' => [
+        'uid' => 'collationvictim',
+        'eduPersonAffiliation' => 'employee',
+        'mail' => 'collationvictim@example.com',
+    ],
     'collationattacker:collationattackerpass' => [
         'uid' => 'collationattacker',
         'eduPersonAffiliation' => 'employee',
@@ -261,11 +268,6 @@ terminus wp "$SITE_ENV" -- option update home "https://$PANTHEON_SITE_URL"
 terminus wp "$SITE_ENV" -- option update siteurl "https://$PANTHEON_SITE_URL"
 terminus wp "$SITE_ENV" -- plugin activate wp-native-php-sessions wp-saml-auth
 terminus wp "$SITE_ENV" -- theme activate "$TERMINUS_SITE"
-# SITE-6023: seed a victim whose email is the unaccented form of the
-# collationattacker IdP account's asserted email. The account-takeover Behat
-# scenario logs in as the attacker and asserts the login is rejected rather
-# than authenticated as this victim.
-terminus wp "$SITE_ENV" -- user create collationvictim collationvictim@example.com --role=administrator --user_pass=collationvictimpass
 terminus wp "$SITE_ENV" -- rewrite structure '/%year%/%monthnum%/%day%/%postname%/'
 # Create writeable directories in /files (aka wp-content/uploads) that SimpleSAMLphp might need.
 terminus wp "$SITE_ENV" -- eval '

--- a/inc/class-wp-saml-auth.php
+++ b/inc/class-wp-saml-auth.php
@@ -445,11 +445,11 @@ class WP_SAML_Auth {
 
 		$existing_user = get_user_by( $get_user_by, $attributes[ $attribute ][0] );
 		if ( $existing_user ) {
-			$field_map = array(
+			$field_map = [
 				'email' => 'user_email',
 				'login' => 'user_login',
 				'slug'  => 'user_nicename',
-			);
+			];
 			$user_field = isset( $field_map[ $get_user_by ] ) ? $field_map[ $get_user_by ] : $get_user_by;
 			if ( $existing_user->$user_field !== $attributes[ $attribute ][0] ) {
 				return new WP_Error( 'wp_saml_auth_attribute_mismatch', esc_html__( 'SAML attribute does not exactly match the existing user. Please contact your administrator.', 'wp-saml-auth' ) );

--- a/inc/class-wp-saml-auth.php
+++ b/inc/class-wp-saml-auth.php
@@ -451,7 +451,7 @@ class WP_SAML_Auth {
 				'slug'  => 'user_nicename',
 			];
 			$user_field = isset( $field_map[ $get_user_by ] ) ? $field_map[ $get_user_by ] : $get_user_by;
-			if ( $existing_user->$user_field !== $attributes[ $attribute ][0] ) {
+			if ( mb_strtolower( $existing_user->$user_field, 'UTF-8' ) !== mb_strtolower( $attributes[ $attribute ][0], 'UTF-8' ) ) {
 				return new WP_Error( 'wp_saml_auth_attribute_mismatch', esc_html__( 'SAML attribute does not exactly match the existing user. Please contact your administrator.', 'wp-saml-auth' ) );
 			}
 

--- a/inc/class-wp-saml-auth.php
+++ b/inc/class-wp-saml-auth.php
@@ -445,6 +445,16 @@ class WP_SAML_Auth {
 
 		$existing_user = get_user_by( $get_user_by, $attributes[ $attribute ][0] );
 		if ( $existing_user ) {
+			$field_map = array(
+				'email' => 'user_email',
+				'login' => 'user_login',
+				'slug'  => 'user_nicename',
+			);
+			$user_field = isset( $field_map[ $get_user_by ] ) ? $field_map[ $get_user_by ] : $get_user_by;
+			if ( $existing_user->$user_field !== $attributes[ $attribute ][0] ) {
+				return new WP_Error( 'wp_saml_auth_attribute_mismatch', esc_html__( 'SAML attribute does not exactly match the existing user. Please contact your administrator.', 'wp-saml-auth' ) );
+			}
+
 			/**
 			 * Runs after a existing user has been authenticated in WordPress
 			 *

--- a/tests/behat/0-login.feature
+++ b/tests/behat/0-login.feature
@@ -31,3 +31,18 @@ Feature: SAML Login
     And I press "submit"
     Then print current URL
     And I should see "Incorrect username or password"
+
+  # SITE-6023: the collationattacker IdP account asserts an accented variant
+  # (collátionvictim@example.com) of the seeded victim's email
+  # (collationvictim@example.com). An accent-insensitive DB collation makes
+  # get_user_by() return the victim, so without the fix the attacker would be
+  # authenticated as the victim. The plugin must reject the near-match instead.
+  Scenario: Rejects a SAML login whose email only matches by collation
+    Given I am on "wp-login.php"
+    Then print current URL
+    And I fill in "username" with "collationattacker"
+    And I fill in "password" with "collationattackerpass"
+    And I press "submit"
+    Then I follow the SAML redirect manually
+    Then print current URL
+    And I should see "SAML attribute does not exactly match the existing user"

--- a/tests/behat/0-login.feature
+++ b/tests/behat/0-login.feature
@@ -32,11 +32,26 @@ Feature: SAML Login
     Then print current URL
     And I should see "Incorrect username or password"
 
+  # SITE-6023: provision the victim via SAML so a real WordPress user exists
+  # with the unaccented email (collationvictim@example.com). This runs in the
+  # default suite (after the upstream core suite), so it does not perturb the
+  # core tests' assumption of a clean user list.
+  Scenario: A victim provisions via SAML
+    Given I am on "wp-login.php"
+    Then print current URL
+    And I fill in "username" with "collationvictim"
+    And I fill in "password" with "collationvictimpass"
+    And I press "submit"
+    Then I follow the SAML redirect manually
+    Then print current URL
+    And the "email" field should contain "collationvictim@example.com"
+
   # SITE-6023: the collationattacker IdP account asserts an accented variant
-  # (collátionvictim@example.com) of the seeded victim's email
-  # (collationvictim@example.com). An accent-insensitive DB collation makes
-  # get_user_by() return the victim, so without the fix the attacker would be
-  # authenticated as the victim. The plugin must reject the near-match instead.
+  # (collátionvictim@example.com) of the victim's email
+  # (collationvictim@example.com) provisioned above. An accent-insensitive DB
+  # collation makes get_user_by() return the victim, so without the fix the
+  # attacker would be authenticated as the victim. The plugin must reject the
+  # near-match instead.
   Scenario: Rejects a SAML login whose email only matches by collation
     Given I am on "wp-login.php"
     Then print current URL

--- a/tests/phpunit/test-authentication.php
+++ b/tests/phpunit/test-authentication.php
@@ -115,6 +115,114 @@ class Test_Authentication extends WP_UnitTestCase {
 		$this->assertFalse( WP_SAML_Auth::get_instance()->get_provider()->isAuthenticated() );
 	}
 
+	public function data_saml_lookup_field_comparison() {
+		return array(
+			'exact email authenticates'          => array( 'email', 'wpreport@example.test', true ),
+			'case-variant email authenticates'   => array( 'email', 'WpReport@Example.test', true ),
+			'accent-variant email is rejected'   => array( 'email', 'wpréport@example.test', false ),
+			'exact login authenticates'          => array( 'login', 'wpreport', true ),
+			'case-variant login authenticates'   => array( 'login', 'WpReport', true ),
+			'accent-variant login is rejected'   => array( 'login', 'wpréport', false ),
+		);
+	}
+
+	/**
+	 * SITE-6023: an attacker who signs in via SAML for the first time with an
+	 * accented variant of a victim's email/login must NOT be authenticated as
+	 * the victim.
+	 *
+	 * This exercises the disclosed attack directly: auto_provision is left at
+	 * its default (true), so a first-time SAML sign-on would normally create a
+	 * new user. Because the accent-insensitive database collation makes
+	 * get_user_by() return the victim, the pre-fix plugin skips provisioning and
+	 * logs the attacker straight into the victim's account. The fix rejects the
+	 * near-match before that happens. Case-only differences stay valid
+	 * (RFC 5321; WordPress usernames are case-insensitive).
+	 *
+	 * @dataProvider data_saml_lookup_field_comparison
+	 */
+	public function test_saml_lookup_field_comparison( $get_user_by, $saml_value, $expect_login ) {
+		$this->options['get_user_by'] = $get_user_by;
+
+		$victim_id = $this->factory->user->create( array(
+			'user_login' => 'wpreport',
+			'user_email' => 'wpreport@example.test',
+		) );
+
+		// Precondition: the database lookup finds the victim for every variant.
+		// With an accent-insensitive collation (e.g. utf8mb4_unicode_520_ci),
+		// this collision is what makes the account takeover possible.
+		$found = get_user_by( $get_user_by, $saml_value );
+		$this->assertInstanceOf( 'WP_User', $found );
+		$this->assertEquals( $victim_id, $found->ID );
+
+		if ( ! $expect_login ) {
+			// The rejection cases only reproduce the vulnerability if the users
+			// table collation actually treats the accented value as equal. If a
+			// future WordPress/DB change made it accent-sensitive, get_user_by()
+			// above would still match by case only, but the fix's mismatch check
+			// would no longer be the thing under test. Skip loudly rather than
+			// pass for the wrong reason.
+			$this->skip_unless_accent_insensitive( $get_user_by );
+		}
+
+		$attribute = 'email' === $get_user_by ? 'mail' : 'uid';
+		$user = $this->saml_signon_with_attributes( array( $attribute => array( $saml_value ) ) );
+
+		if ( $expect_login ) {
+			$this->assertInstanceOf( 'WP_User', $user );
+			$this->assertEquals( $victim_id, $user->ID );
+			$this->assertEquals( $victim_id, get_current_user_id() );
+			return;
+		}
+
+		// The near-match must be rejected, no one logged in...
+		$this->assertInstanceOf( 'WP_Error', $user );
+		$this->assertEquals( 'wp_saml_auth_attribute_mismatch', $user->get_error_code() );
+		$this->assertEquals( 0, get_current_user_id() );
+
+		// ...and, crucially, auto-provision must not have silently created a
+		// second (attacker) account. Only the victim we seeded should exist.
+		$this->assertCount( 1, get_users( array( 'search' => 'wpreport', 'search_columns' => array( 'user_login', 'user_email' ) ) ) );
+	}
+
+	/**
+	 * Skip the test unless the users table's collation treats an accented
+	 * character as equal to its unaccented form. The SITE-6023 collision only
+	 * exists under an accent-insensitive collation (e.g. utf8mb4_unicode_520_ci).
+	 *
+	 * @param string $get_user_by Lookup field ('email' or 'login'), used to pick
+	 *                            the column whose collation governs the lookup.
+	 */
+	private function skip_unless_accent_insensitive( $get_user_by ) {
+		global $wpdb;
+		$column = 'email' === $get_user_by ? 'user_email' : 'user_login';
+		$collation = $wpdb->get_var(
+			$wpdb->prepare(
+				'SELECT COLLATION_NAME FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = %s AND TABLE_NAME = %s AND COLUMN_NAME = %s',
+				DB_NAME,
+				$wpdb->users,
+				$column
+			)
+		);
+		if ( empty( $collation ) ) {
+			$this->markTestSkipped( "Could not determine collation of {$wpdb->users}.{$column}." );
+		}
+		$accent_insensitive = $wpdb->get_var( "SELECT 'wpréport' = 'wpreport' COLLATE {$collation}" );
+		if ( '1' !== (string) $accent_insensitive ) {
+			$this->markTestSkipped(
+				"SITE-6023 regression requires an accent-insensitive collation on {$wpdb->users}.{$column}; "
+				. "found '{$collation}', which is accent-sensitive, so the account-takeover collision cannot be reproduced here."
+			);
+		}
+	}
+
+	private function saml_signon_with_attributes( array $attributes ) {
+		$GLOBALS['wp_saml_auth_current_user'] = $attributes;
+		$_GET['action'] = 'wp-saml-auth';
+		return wp_signon();
+	}
+
 	private function saml_signon( $username ) {
 		$this->set_saml_auth_user( $username );
 		$_GET['action'] = 'wp-saml-auth';

--- a/tests/phpunit/test-authentication.php
+++ b/tests/phpunit/test-authentication.php
@@ -127,17 +127,23 @@ class Test_Authentication extends WP_UnitTestCase {
 	}
 
 	/**
-	 * SITE-6023: an attacker who signs in via SAML for the first time with an
-	 * accented variant of a victim's email/login must NOT be authenticated as
-	 * the victim.
+	 * SITE-6023: SAML user lookup must compare the asserted value against the
+	 * matched user's stored value, so a value that only matches by collation is
+	 * rejected while legitimate variants still authenticate.
 	 *
-	 * This exercises the disclosed attack directly: auto_provision is left at
+	 * The data provider covers both lookup modes (email, login) with three
+	 * kinds of value:
+	 *  - exact: authenticates.
+	 *  - case-variant (User@Example vs user@example): authenticates, because
+	 *    case is normalized (RFC 5321; WordPress usernames are case-insensitive).
+	 *  - accent-variant (wpréport vs wpreport): rejected.
+	 *
+	 * The accent-variant case is the disclosed attack. auto_provision is left at
 	 * its default (true), so a first-time SAML sign-on would normally create a
-	 * new user. Because the accent-insensitive database collation makes
+	 * new user; because the accent-insensitive database collation makes
 	 * get_user_by() return the victim, the pre-fix plugin skips provisioning and
 	 * logs the attacker straight into the victim's account. The fix rejects the
-	 * near-match before that happens. Case-only differences stay valid
-	 * (RFC 5321; WordPress usernames are case-insensitive).
+	 * near-match before that happens.
 	 *
 	 * @dataProvider data_saml_lookup_field_comparison
 	 */


### PR DESCRIPTION
  Fixes vulnerability due to MySQL's default accent-insensitive
  collation makes `get_user_by()` treat the two values as equal.

  ## Changes

  - `WP_SAML_Auth::do_saml_authentication()` now re-verifies the matched user
    in PHP with a case-insensitive but accent-sensitive (`mb_strtolower`)
    comparison, and rejects the login with a `WP_Error` when the SAML
    attribute doesn't exactly match the stored user field.
  - PHPUnit regression tests covering the collation-bypass scenario.
  - Behat end-to-end scenario: a victim auto-provisions via SAML, then an
    attacker with the accented-variant email is rejected.