### PR TITLE
Release 2.3.4

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -2,7 +2,6 @@
 .github
 .wordpress-org
 tests
-vendor
 bin
 .DS_Store
 Thumbs.db

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 **Contributors:** [getpantheon](https://profiles.wordpress.org/getpantheon/), [danielbachhuber](https://profiles.wordpress.org/danielbachhuber/), [outlandish-josh](https://profiles.wordpress.org/outlandish-josh/), [jazzs3quence](https://profiles.wordpress.org/jazzs3quence/), [lcatlett](https://profiles.wordpress.org/lcatlett/), [AnaisPantheor](https://profiles.wordpress.org/AnaisPantheor/), [metasim](https://profiles.wordpress.org/metasim/)  
 **Tags:** authentication, SAML  
 **Requires at least:** 6.4  
-**Tested up to:** 6.9  
+**Tested up to:** 7.0  
 **Requires PHP:** 7.4  
 **Stable tag:** 2.3.4-dev  
 **License:** GPLv2 or later  

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 **Requires at least:** 6.4  
 **Tested up to:** 7.0  
 **Requires PHP:** 7.4  
-**Stable tag:** 2.3.4-dev  
+**Stable tag:** 2.3.4  
 **License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -406,7 +406,7 @@ Minimum supported PHP version is 7.3.
 
 ## Changelog ##
 
-### 2.3.4-dev ###
+### 2.3.4 (12 August 2026) ###
 * Restores the `vendor` directory to the WordPress.org package. 2.3.3 shipped without it, which broke SAML login for sites that took the update [[#499](https://github.com/pantheon-systems/wp-saml-auth/pull/499)].
 
 ### 2.3.3 (11 August 2026) ###

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 **Requires at least:** 6.4  
 **Tested up to:** 6.9  
 **Requires PHP:** 7.4  
-**Stable tag:** 2.3.3  
+**Stable tag:** 2.3.4-dev  
 **License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -405,6 +405,9 @@ WP SAML Auth 2.2.0 requires WordPress version 6.4 or later.
 Minimum supported PHP version is 7.3.
 
 ## Changelog ##
+
+### 2.3.4-dev ###
+* Restores the `vendor` directory to the WordPress.org package. 2.3.3 shipped without it, which broke SAML login for sites that took the update [[#499](https://github.com/pantheon-systems/wp-saml-auth/pull/499)].
 
 ### 2.3.3 (11 August 2026) ###
 * **Security:** Fixes an account takeover where an accent-insensitive database collation could match a SAML attribute to the wrong WordPress user. User lookup is now verified with a case-insensitive, accent-sensitive comparison [[#495](https://github.com/pantheon-systems/wp-saml-auth/pull/495)].

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: authentication, SAML
 Requires at least: 6.4
 Tested up to: 7.0
 Requires PHP: 7.4
-Stable tag: 2.3.3
+Stable tag: 2.3.4-dev
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -397,6 +397,9 @@ Minimum supported PHP version is 7.3.
 
 
 == Changelog ==
+
+= 2.3.4-dev =
+* Restores the `vendor` directory to the WordPress.org package. 2.3.3 shipped without it, which broke SAML login for sites that took the update [[#499](https://github.com/pantheon-systems/wp-saml-auth/pull/499)].
 
 = 2.3.3 (11 August 2026) =
 * **Security:** Fixes an account takeover where an accent-insensitive database collation could match a SAML attribute to the wrong WordPress user. User lookup is now verified with a case-insensitive, accent-sensitive comparison [[#495](https://github.com/pantheon-systems/wp-saml-auth/pull/495)].

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: authentication, SAML
 Requires at least: 6.4
 Tested up to: 7.0
 Requires PHP: 7.4
-Stable tag: 2.3.4-dev
+Stable tag: 2.3.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -398,7 +398,7 @@ Minimum supported PHP version is 7.3.
 
 == Changelog ==
 
-= 2.3.4-dev =
+= 2.3.4 (12 August 2026) =
 * Restores the `vendor` directory to the WordPress.org package. 2.3.3 shipped without it, which broke SAML login for sites that took the update [[#499](https://github.com/pantheon-systems/wp-saml-auth/pull/499)].
 
 = 2.3.3 (11 August 2026) =

--- a/wp-saml-auth.php
+++ b/wp-saml-auth.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: WP SAML Auth
- * Version: 2.3.4-dev
+ * Version: 2.3.4
  * Description: SAML authentication for WordPress, using SimpleSAMLphp.
  * Author: Pantheon
  * Author URI: https://pantheon.io

--- a/wp-saml-auth.php
+++ b/wp-saml-auth.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: WP SAML Auth
- * Version: 2.3.3
+ * Version: 2.3.4-dev
  * Description: SAML authentication for WordPress, using SimpleSAMLphp.
  * Author: Pantheon
  * Author URI: https://pantheon.io


### PR DESCRIPTION
## Summary

Release 2.3.4. Restores the `vendor` directory to the WordPress.org package.

- Remove `vendor` from `.distignore` so the wp.org package again ships the Composer dependencies, notably `onelogin/php-saml`.
- Version bump to `2.3.4` in `wp-saml-auth.php`, `readme.txt`, and `README.md`, with a dated changelog entry in both readmes.
- Sync `Tested up to` in `README.md` to `7.0`, matching `readme.txt`.

## ⚠️ Merge with a merge commit

Per `CONTRIBUTING.md`, do not squash or rebase this PR. If the UI only offers squash/rebase:

```bash
git checkout release
git merge release_2.3.4
git push origin release
```

## Context

[SITE-6079](https://getpantheon.atlassian.net/browse/SITE-6079) / fixes #498

The 2.3.3 zip on wp.org shipped without `vendor/`, breaking SAML on any site that took the update. 2.3.2 was fine.

`10up/action-wordpress-plugin-deploy` prefers `.distignore` over `.gitattributes` when a `.distignore` exists ([deploy.sh#L120-L126](https://github.com/10up/action-wordpress-plugin-deploy/blob/2.3.0/deploy.sh#L120-L126)):

```bash
if [[ -e "$GITHUB_WORKSPACE/.distignore" ]]; then
	echo "ℹ︎ Using .distignore"
	rsync -rc --exclude-from="$GITHUB_WORKSPACE/.distignore" "$GITHUB_WORKSPACE/" trunk/ --delete --delete-excluded
else
	echo "ℹ︎ Using .gitattributes"
```

`.distignore` was added in #488 for the plugin-check migration and listed `vendor`. `.gitattributes` never had a `vendor export-ignore` entry, so every release before 2.3.3 took the `.gitattributes` path and shipped `vendor/`. Adding `.distignore` silently flipped the deploy to the excluding path.

The 2.3.3 tag and GitHub release do contain `vendor/`: `build-tag-release` runs `composer install --no-dev -o` and `git add -f vendor/*` before tagging. Only the SVN/wp.org copy was stripped. `wp dist-archive` in `wporg-validator.yml` reads the same `.distignore`, so plugin-check was also validating a vendor-less build.

## Why this targets `release` and not `main`

The normal flow is fix into `main`, then reconcile into `release`. That is currently impossible. The org ruleset `TL1 - Critical` targets `~DEFAULT_BRANCH` / `refs/heads/main` / `refs/heads/master` only, and enforces `required_linear_history` plus `required_signatures`. Fast-forwarding `main` to `release` was rejected:

```
- This branch must not contain merge commits.
  35be29e   (Merge pull request #481 from pantheon-systems/release-2.3.3)
- Commits must have verified signatures.
  a4dfa2c   (Release 2.3.3 — github-actions[bot], unsigned)
```

Both are inherent to the release process: release PRs land on `release` as merge commits by design, and `build-tag-release` commits `vendor/` as an unsigned bot commit. `release` itself carries no rules, so staging the release here works today. Per discussion with @philiptyler, the default-branch reconcile is deferred and tracked separately.

Supersedes #499, which targeted `main`.

## Test plan

- [ ] Confirm the deploy step logs `ℹ︎ Using .distignore` and that `vendor/` is in the rsync payload.
- [ ] Before publishing the draft release, confirm the `2.3.4` tag contains `vendor/onelogin/php-saml/`.
- [ ] After publish, verify `https://downloads.wordpress.org/plugin/wp-saml-auth.2.3.4.zip` contains `vendor/onelogin/php-saml/`.
- [ ] Confirm Packagist accepts 2.3.4. The blocked 2.3.3 update clears once a new tag lands.
- [ ] Close #498.

Local simulation of the deploy rsync against the patched `.distignore` keeps `vendor/` and still drops `tests/` and `.distignore`:

```
trunk/inc/class.php
trunk/vendor/autoload.php
trunk/vendor/onelogin/php-saml/lib.php
trunk/wp-saml-auth.php
```

## Release hygiene

Do not delete and re-create the `2.3.4` tag. The action's tag step is a bare `git tag`/`git push` with no `-f`, and clearing the tag by hand is what moved 2.3.3 from `ed8dd70` to `d5895ac` and tripped Packagist's version immutability check.

## Follow-up

- Reconcile the default branch. `main` is still on `2.3.3-dev` and cannot ingest `release` under the current ruleset. Needs either a scoped ruleset exception via github-terraform or a documented squash path in `CONTRIBUTING.md`.
- `wp-saml-auth-internal` has the same `.distignore` + `build_composer_assets: "true"` combination and needs the same fix.
- `plugin-release-actions/build-tag-release` is pinned to `@main` and produces unsigned bot commits. Worth hardening.

## References

- Jira: [SITE-6079](https://getpantheon.atlassian.net/browse/SITE-6079)
- GitHub issue: #498
- Regressing PR: #488
- Superseded PR: #499


[SITE-6079]: https://getpantheon.atlassian.net/browse/SITE-6079?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SITE-6079]: https://getpantheon.atlassian.net/browse/SITE-6079?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ