### PR TITLE
Reconcile main with release and prepare 2.3.5-dev

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -2,7 +2,6 @@
 .github
 .wordpress-org
 tests
-vendor
 bin
 .DS_Store
 Thumbs.db

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 **Contributors:** [getpantheon](https://profiles.wordpress.org/getpantheon/), [danielbachhuber](https://profiles.wordpress.org/danielbachhuber/), [outlandish-josh](https://profiles.wordpress.org/outlandish-josh/), [jazzs3quence](https://profiles.wordpress.org/jazzs3quence/), [lcatlett](https://profiles.wordpress.org/lcatlett/), [AnaisPantheor](https://profiles.wordpress.org/AnaisPantheor/), [metasim](https://profiles.wordpress.org/metasim/)  
 **Tags:** authentication, SAML  
 **Requires at least:** 6.4  
-**Tested up to:** 6.9  
+**Tested up to:** 7.0  
 **Requires PHP:** 7.4  
 **Stable tag:** 2.3.4-dev  
 **License:** GPLv2 or later  

--- a/README.md
+++ b/README.md
@@ -407,7 +407,9 @@ Minimum supported PHP version is 7.3.
 ## Changelog ##
 
 ### 2.3.3 (11 August 2026) ###
+* **Security:** Fixes an account takeover where an accent-insensitive database collation could match a SAML attribute to the wrong WordPress user. User lookup is now verified with a case-insensitive, accent-sensitive comparison [[#495](https://github.com/pantheon-systems/wp-saml-auth/pull/495)].
 * Adds PHP 8.5 compatibility [[#482](https://github.com/pantheon-systems/wp-saml-auth/pull/482)].
+* Updates dependencies [[#492](https://github.com/pantheon-systems/wp-saml-auth/pull/492)][[#494](https://github.com/pantheon-systems/wp-saml-auth/pull/494)].
 
 ### 2.3.2 (15 May 2026) ###
 * Update dependencies [[#477](https://github.com/pantheon-systems/wp-saml-auth/pull/477)].

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 **Requires at least:** 6.4  
 **Tested up to:** 7.0  
 **Requires PHP:** 7.4  
-**Stable tag:** 2.3.4-dev  
+**Stable tag:** 2.3.4  
 **License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -406,7 +406,7 @@ Minimum supported PHP version is 7.3.
 
 ## Changelog ##
 
-### 2.3.4-dev ###
+### 2.3.4 (12 August 2026) ###
 * Restores the `vendor` directory to the WordPress.org package. 2.3.3 shipped without it, which broke SAML login for sites that took the update [[#499](https://github.com/pantheon-systems/wp-saml-auth/pull/499)].
 
 ### 2.3.3 (11 August 2026) ###

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 **Requires at least:** 6.4  
 **Tested up to:** 6.9  
 **Requires PHP:** 7.4  
-**Stable tag:** 2.3.3-dev  
+**Stable tag:** 2.3.3  
 **License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -406,7 +406,7 @@ Minimum supported PHP version is 7.3.
 
 ## Changelog ##
 
-### 2.3.3-dev ###
+### 2.3.3 (11 August 2026) ###
 * Adds PHP 8.5 compatibility [[#482](https://github.com/pantheon-systems/wp-saml-auth/pull/482)].
 
 ### 2.3.2 (15 May 2026) ###

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 **Requires at least:** 6.4  
 **Tested up to:** 6.9  
 **Requires PHP:** 7.4  
-**Stable tag:** 2.3.3  
+**Stable tag:** 2.3.4-dev  
 **License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -405,6 +405,9 @@ WP SAML Auth 2.2.0 requires WordPress version 6.4 or later.
 Minimum supported PHP version is 7.3.
 
 ## Changelog ##
+
+### 2.3.4-dev ###
+* Restores the `vendor` directory to the WordPress.org package. 2.3.3 shipped without it, which broke SAML login for sites that took the update [[#499](https://github.com/pantheon-systems/wp-saml-auth/pull/499)].
 
 ### 2.3.3 (11 August 2026) ###
 * **Security:** Fixes an account takeover where an accent-insensitive database collation could match a SAML attribute to the wrong WordPress user. User lookup is now verified with a case-insensitive, accent-sensitive comparison [[#495](https://github.com/pantheon-systems/wp-saml-auth/pull/495)].

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 **Requires at least:** 6.4  
 **Tested up to:** 7.0  
 **Requires PHP:** 7.4  
-**Stable tag:** 2.3.4  
+**Stable tag:** 2.3.5-dev  
 **License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -405,6 +405,8 @@ WP SAML Auth 2.2.0 requires WordPress version 6.4 or later.
 Minimum supported PHP version is 7.3.
 
 ## Changelog ##
+
+### 2.3.5-dev ###
 
 ### 2.3.4 (12 August 2026) ###
 * Restores the `vendor` directory to the WordPress.org package. 2.3.3 shipped without it, which broke SAML login for sites that took the update [[#499](https://github.com/pantheon-systems/wp-saml-auth/pull/499)].

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: authentication, SAML
 Requires at least: 6.4
 Tested up to: 7.0
 Requires PHP: 7.4
-Stable tag: 2.3.4
+Stable tag: 2.3.5-dev
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -397,6 +397,8 @@ Minimum supported PHP version is 7.3.
 
 
 == Changelog ==
+
+= 2.3.5-dev =
 
 = 2.3.4 (12 August 2026) =
 * Restores the `vendor` directory to the WordPress.org package. 2.3.3 shipped without it, which broke SAML login for sites that took the update [[#499](https://github.com/pantheon-systems/wp-saml-auth/pull/499)].

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: authentication, SAML
 Requires at least: 6.4
 Tested up to: 7.0
 Requires PHP: 7.4
-Stable tag: 2.3.3-dev
+Stable tag: 2.3.3
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -398,7 +398,7 @@ Minimum supported PHP version is 7.3.
 
 == Changelog ==
 
-= 2.3.3-dev =
+= 2.3.3 (11 August 2026) =
 * Adds PHP 8.5 compatibility [[#482](https://github.com/pantheon-systems/wp-saml-auth/pull/482)].
 
 = 2.3.2 (15 May 2026) =

--- a/readme.txt
+++ b/readme.txt
@@ -399,7 +399,9 @@ Minimum supported PHP version is 7.3.
 == Changelog ==
 
 = 2.3.3 (11 August 2026) =
+* **Security:** Fixes an account takeover where an accent-insensitive database collation could match a SAML attribute to the wrong WordPress user. User lookup is now verified with a case-insensitive, accent-sensitive comparison [[#495](https://github.com/pantheon-systems/wp-saml-auth/pull/495)].
 * Adds PHP 8.5 compatibility [[#482](https://github.com/pantheon-systems/wp-saml-auth/pull/482)].
+* Updates dependencies [[#492](https://github.com/pantheon-systems/wp-saml-auth/pull/492)][[#494](https://github.com/pantheon-systems/wp-saml-auth/pull/494)].
 
 = 2.3.2 (15 May 2026) =
 * Update dependencies [[#477](https://github.com/pantheon-systems/wp-saml-auth/pull/477)].

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: authentication, SAML
 Requires at least: 6.4
 Tested up to: 7.0
 Requires PHP: 7.4
-Stable tag: 2.3.3
+Stable tag: 2.3.4-dev
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -397,6 +397,9 @@ Minimum supported PHP version is 7.3.
 
 
 == Changelog ==
+
+= 2.3.4-dev =
+* Restores the `vendor` directory to the WordPress.org package. 2.3.3 shipped without it, which broke SAML login for sites that took the update [[#499](https://github.com/pantheon-systems/wp-saml-auth/pull/499)].
 
 = 2.3.3 (11 August 2026) =
 * **Security:** Fixes an account takeover where an accent-insensitive database collation could match a SAML attribute to the wrong WordPress user. User lookup is now verified with a case-insensitive, accent-sensitive comparison [[#495](https://github.com/pantheon-systems/wp-saml-auth/pull/495)].

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: authentication, SAML
 Requires at least: 6.4
 Tested up to: 7.0
 Requires PHP: 7.4
-Stable tag: 2.3.4-dev
+Stable tag: 2.3.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -398,7 +398,7 @@ Minimum supported PHP version is 7.3.
 
 == Changelog ==
 
-= 2.3.4-dev =
+= 2.3.4 (12 August 2026) =
 * Restores the `vendor` directory to the WordPress.org package. 2.3.3 shipped without it, which broke SAML login for sites that took the update [[#499](https://github.com/pantheon-systems/wp-saml-auth/pull/499)].
 
 = 2.3.3 (11 August 2026) =

--- a/wp-saml-auth.php
+++ b/wp-saml-auth.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: WP SAML Auth
- * Version: 2.3.4-dev
+ * Version: 2.3.4
  * Description: SAML authentication for WordPress, using SimpleSAMLphp.
  * Author: Pantheon
  * Author URI: https://pantheon.io

--- a/wp-saml-auth.php
+++ b/wp-saml-auth.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: WP SAML Auth
- * Version: 2.3.4
+ * Version: 2.3.5-dev
  * Description: SAML authentication for WordPress, using SimpleSAMLphp.
  * Author: Pantheon
  * Author URI: https://pantheon.io

--- a/wp-saml-auth.php
+++ b/wp-saml-auth.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: WP SAML Auth
- * Version: 2.3.3-dev
+ * Version: 2.3.3
  * Description: SAML authentication for WordPress, using SimpleSAMLphp.
  * Author: Pantheon
  * Author URI: https://pantheon.io

--- a/wp-saml-auth.php
+++ b/wp-saml-auth.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: WP SAML Auth
- * Version: 2.3.3
+ * Version: 2.3.4-dev
  * Description: SAML authentication for WordPress, using SimpleSAMLphp.
  * Author: Pantheon
  * Author URI: https://pantheon.io


### PR DESCRIPTION
Reconciles `main` with `release` using a linear history, then opens 2.3.5 for development.

`main` had fallen behind `release` by six content commits. Replaying them with `cherry-pick` instead of merging drops the two merge commits (`02b7847`, `35be29e`), so `main` picks up the content without the merge topology.

Verified before the dev bump: the branch tree was byte-identical to `origin/release` (both `2ed928ed`), and `git log --merges origin/main..reconcile-linear` is empty.

### Commits

| Commit | Change |
| --- | --- |
| `672caac` | Release 2.3.3 |
| `8e9dc3b` | Add 2.3.3 changelog entries (#497) |
| `2c5c97f` | fix(ci): [SITE-6079] stop excluding vendor from the wp.org package |
| `dd1fdf2` | Prepare 2.3.4-dev |
| `afec50d` | docs(readme): sync Tested up to with readme.txt |
| `3b559b0` | Release 2.3.4 |
| `155c8df` | Prepare 2.3.5-dev |

Only `2c5c97f` is a functional change: `vendor` is removed from `.distignore`, since 2.3.3 shipped to wp.org without `onelogin/php-saml` and broke SAML login for sites that took the update. The rest are version strings and changelog entries.

### Notes

- **This supersedes #499**, which carries the same `.distignore` fix. Close #499 rather than merging it.
- **Merge with rebase or fast-forward, not a merge commit** — a merge commit reintroduces exactly what this strips out.
- The `2.3.4` tag points at `89b335e`, which is on no branch and commits a `vendor/` tree as the wp.org build artifact. It is deliberately not part of this reconcile; `origin/release` is the source-history reference.


[SITE-6079]: https://getpantheon.atlassian.net/browse/SITE-6079?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ