### PR TITLE
chore: group dependabot minor/patch updates by ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,11 @@ updates:
     day: tuesday
   target-branch: "develop"
   open-pull-requests-limit: 99
+  groups:
+    composer-minor-patch:
+      update-types:
+      - minor
+      - patch
   ignore:
   - dependency-name: onelogin/php-saml
     versions:
@@ -29,8 +34,17 @@ updates:
     day: tuesday
   target-branch: "main"
   open-pull-requests-limit: 99
+  groups:
+    npm-minor-patch:
+      update-types:
+      - minor
+      - patch
 - package-ecosystem: "github-actions"
   target-branch: "main"
   directory: "/"
   schedule:
     interval: daily
+  groups:
+    github-actions:
+      patterns:
+      - "*"


### PR DESCRIPTION
Groups Dependabot updates in \`.github/dependabot.yml\` so routine bumps land as a single PR per ecosystem instead of one PR per dependency, mirroring the convention already in pantheon-systems/pantheon-hud.

- composer: minor/patch updates grouped under \`composer-minor-patch\`
- npm: minor/patch updates grouped under \`npm-minor-patch\`
- github-actions: all updates grouped under \`github-actions\` (tag-versioned, not strict semver, so grouped by pattern rather than update-type)

Major version bumps for composer and npm are not included in the groups, so they continue to open as individual PRs. No existing keys (including the per-ecosystem \`target-branch\` values) were changed or removed.