### PR TITLE
SITE-5791: pin actions to Node 24 release SHAs

### DIFF
--- a/.github/workflows/behat-tests.yml
+++ b/.github/workflows/behat-tests.yml
@@ -44,12 +44,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
       - name: Setup PHP ${{ matrix.php }}
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           php-version: ${{ matrix.php }}
           extensions: mysqli, intl, mbstring
@@ -62,10 +62,10 @@ jobs:
           sudo apt-get install -y mysql-client sendmail rsync
 
       - name: Setup WP-CLI
-        uses: godaddy-wordpress/setup-wp-cli@1
+        uses: godaddy-wordpress/setup-wp-cli@80c9a89bd347082429795c0f12acf567e2c390d4 # 1
 
       - name: Cache Composer dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: vendor
           key: composer-${{ hashFiles('composer.lock') }}-${{ matrix.php }}
@@ -99,7 +99,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -107,19 +107,19 @@ jobs:
           lfs: false
 
       - name: Setup PHP 8.2
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           php-version: "8.2"
           tools: composer:v2
           coverage: none
 
       - name: Install Terminus
-        uses: pantheon-systems/terminus-github-actions@v1
+        uses: pantheon-systems/terminus-github-actions@409451ede17f75acac08f42edc823fee6c435057 # v1.2.8
         with:
           pantheon-machine-token: ${{ secrets.TERMINUS_TOKEN }}
 
       - name: SSH agent
-        uses: webfactory/ssh-agent@v0.9.1
+        uses: webfactory/ssh-agent@e83874834305fe9a4a2997156cb26c5de65a8555 # v0.10.0
         with:
           ssh-private-key: ${{ secrets.SITE_OWNER_SSH_PRIVATE_KEY }}
           log-public-key: true
@@ -207,12 +207,12 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
       - name: Install Terminus
-        uses: pantheon-systems/terminus-github-actions@v1
+        uses: pantheon-systems/terminus-github-actions@409451ede17f75acac08f42edc823fee6c435057 # v1.2.8
         with:
           pantheon-machine-token: ${{ secrets.TERMINUS_TOKEN }}
 

--- a/.github/workflows/behat-tests.yml
+++ b/.github/workflows/behat-tests.yml
@@ -114,7 +114,7 @@ jobs:
           coverage: none
 
       - name: Install Terminus
-        uses: pantheon-systems/terminus-github-actions@409451ede17f75acac08f42edc823fee6c435057 # v1.2.8
+        uses: pantheon-systems/terminus-github-actions@b0a005d0e886678b25cb6cd7833cf8d8cf779900 # v1.2.9
         with:
           pantheon-machine-token: ${{ secrets.TERMINUS_TOKEN }}
 
@@ -212,7 +212,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Terminus
-        uses: pantheon-systems/terminus-github-actions@409451ede17f75acac08f42edc823fee6c435057 # v1.2.8
+        uses: pantheon-systems/terminus-github-actions@b0a005d0e886678b25cb6cd7833cf8d8cf779900 # v1.2.9
         with:
           pantheon-machine-token: ${{ secrets.TERMINUS_TOKEN }}
 

--- a/.github/workflows/build-tag-release.yml
+++ b/.github/workflows/build-tag-release.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - name: Build, tag, and release
-      uses: pantheon-systems/plugin-release-actions/build-tag-release@554b455c9cb024ccf20147a27656fb198ce6f0cc # main 2026-08-13T21:25:05Z
+      uses: pantheon-systems/plugin-release-actions/build-tag-release@8c76f0613b094d9812da9257030e534c4d8eeb6c # v0.5.6
       with:
         gh_token: ${{ secrets.GITHUB_TOKEN }}
         build_composer_assets: "true"

--- a/.github/workflows/build-tag-release.yml
+++ b/.github/workflows/build-tag-release.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - name: Build, tag, and release
       uses: pantheon-systems/plugin-release-actions/build-tag-release@main
       with:

--- a/.github/workflows/build-tag-release.yml
+++ b/.github/workflows/build-tag-release.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - name: Build, tag, and release
-      uses: pantheon-systems/plugin-release-actions/build-tag-release@main
+      uses: pantheon-systems/plugin-release-actions/build-tag-release@554b455c9cb024ccf20147a27656fb198ce6f0cc # main 2026-08-13T21:25:05Z
       with:
         gh_token: ${{ secrets.GITHUB_TOKEN }}
         build_composer_assets: "true"

--- a/.github/workflows/composer-diff.yml
+++ b/.github/workflows/composer-diff.yml
@@ -12,13 +12,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
       - name: Generate composer diff
         id: composer_diff
-        uses: IonBazan/composer-diff-action@v1
-      - uses: marocchino/sticky-pull-request-comment@v2
+        uses: IonBazan/composer-diff-action@e2022e8718d05cc6e4e5990a06fc928c75837f76 # v2.0.0
+      - uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
         if: ${{ steps.composer_diff.outputs.composer_diff_exit_code != 0 }}
         with:
           header: composer-diff

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -6,14 +6,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
-      - uses: pantheon-systems/validate-readme-spacing@v1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: pantheon-systems/validate-readme-spacing@13c5e619ef5fc39632292f1f5261ab31d1904208 # v1.0.6
   lint:
     name: Lint
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Lint
         run: |
           composer install
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Run ShellCheck
         run: |
           shellcheck --version

--- a/.github/workflows/phpcbf.yml
+++ b/.github/workflows/phpcbf.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.ref }}
       - name: Install Composer dependencies and run PHPCBF

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -13,7 +13,7 @@ jobs:
     name: Draft Release PR
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Create Draft Release PR
         uses: pantheon-systems/plugin-release-actions/release-pr@main
         with:

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Create Draft Release PR
-        uses: pantheon-systems/plugin-release-actions/release-pr@main
+        uses: pantheon-systems/plugin-release-actions/release-pr@554b455c9cb024ccf20147a27656fb198ce6f0cc # main 2026-08-13T21:25:05Z
         with:
           gh_token: ${{ github.token }}
           readme_md: README.md

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Create Draft Release PR
-        uses: pantheon-systems/plugin-release-actions/release-pr@554b455c9cb024ccf20147a27656fb198ce6f0cc # main 2026-08-13T21:25:05Z
+        uses: pantheon-systems/plugin-release-actions/release-pr@8c76f0613b094d9812da9257030e534c4d8eeb6c # v0.5.6
         with:
           gh_token: ${{ github.token }}
           readme_md: README.md

--- a/.github/workflows/validate-plugin-tested-up-to-version.yml
+++ b/.github/workflows/validate-plugin-tested-up-to-version.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     name: Validate Plugin Tested Up To
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
-      - uses: jazzsequence/action-validate-plugin-version@v2
+      - uses: jazzsequence/action-validate-plugin-version@6b8b403af6e9eefde9c36c0d342b717d5952b518 # v2.0.1
         with:
           branch: 'main'

--- a/.github/workflows/wordpress-plugin-deploy.yml
+++ b/.github/workflows/wordpress-plugin-deploy.yml
@@ -7,9 +7,9 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - name: WordPress Plugin Deploy
-      uses: 10up/action-wordpress-plugin-deploy@2.3.0
+      uses: 10up/action-wordpress-plugin-deploy@54bd289b8525fd23a5c365ec369185f2966529c2 # 2.3.0
       env:
         SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
         SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}

--- a/.github/workflows/wporg-validator.yml
+++ b/.github/workflows/wporg-validator.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
     - name: Setup PHP 8.4
-      uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1 # v2
+      uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
       with:
         php-version: "8.4"
         extensions: mysqli


### PR DESCRIPTION
GitHub removes Node.js 20 from the runners on 16 September 2026.

This pins every affected action reference in this repo to the commit SHA of a Node 24 release, with the version as a trailing comment. That covers both halves of SITE-5791 in one edit: the SHA pin removes the risk of a tag being repointed at a different commit, and the release bump clears the Node 20 removal.

Pinning `@v4` would not have been enough: v4 of `actions/checkout` and `actions/cache` runs on Node 20 itself, so each reference needed both a SHA and a version bump.

| File | Was | Now | Old runtime |
|---|---|---|---|
| `.github/workflows/behat-tests.yml` | `actions/checkout@v5` | `actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1` | node24 |
| `.github/workflows/behat-tests.yml` | `shivammathur/setup-php@v2` | `shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2` | node24 |
| `.github/workflows/behat-tests.yml` | `godaddy-wordpress/setup-wp-cli@1` | `godaddy-wordpress/setup-wp-cli@80c9a89bd347082429795c0f12acf567e2c390d4 # 1` | composite |
| `.github/workflows/behat-tests.yml` | `actions/cache@v5` | `actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0` | node24 |
| `.github/workflows/behat-tests.yml` | `actions/checkout@v5` | `actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1` | node24 |
| `.github/workflows/behat-tests.yml` | `shivammathur/setup-php@v2` | `shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2` | node24 |
| `.github/workflows/behat-tests.yml` | `pantheon-systems/terminus-github-actions@v1` | `pantheon-systems/terminus-github-actions@409451ede17f75acac08f42edc823fee6c435057 # v1.2.8` | composite |
| `.github/workflows/behat-tests.yml` | `webfactory/ssh-agent@v0.9.1` | `webfactory/ssh-agent@e83874834305fe9a4a2997156cb26c5de65a8555 # v0.10.0` | node20 |
| `.github/workflows/behat-tests.yml` | `actions/checkout@v5` | `actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1` | node24 |
| `.github/workflows/behat-tests.yml` | `pantheon-systems/terminus-github-actions@v1` | `pantheon-systems/terminus-github-actions@409451ede17f75acac08f42edc823fee6c435057 # v1.2.8` | composite |
| `.github/workflows/build-tag-release.yml` | `actions/checkout@v5` | `actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1` | node24 |
| `.github/workflows/composer-diff.yml` | `actions/checkout@v5` | `actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1` | node24 |
| `.github/workflows/composer-diff.yml` | `IonBazan/composer-diff-action@v1` | `IonBazan/composer-diff-action@e2022e8718d05cc6e4e5990a06fc928c75837f76 # v2.0.0` | docker |
| `.github/workflows/composer-diff.yml` | `marocchino/sticky-pull-request-comment@v2` | `marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5` | node20 |
| `.github/workflows/lint-test.yml` | `actions/checkout@v5` | `actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1` | node24 |
| `.github/workflows/lint-test.yml` | `pantheon-systems/validate-readme-spacing@v1` | `pantheon-systems/validate-readme-spacing@13c5e619ef5fc39632292f1f5261ab31d1904208 # v1.0.6` | composite |
| `.github/workflows/lint-test.yml` | `actions/checkout@v5` | `actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1` | node24 |
| `.github/workflows/lint-test.yml` | `actions/checkout@v5` | `actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1` | node24 |
| `.github/workflows/phpcbf.yml` | `actions/checkout@v5` | `actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1` | node24 |
| `.github/workflows/release-pr.yml` | `actions/checkout@v4` | `actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1` | node20 |
| `.github/workflows/validate-plugin-tested-up-to-version.yml` | `actions/checkout@v5` | `actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1` | node24 |
| `.github/workflows/validate-plugin-tested-up-to-version.yml` | `jazzsequence/action-validate-plugin-version@v2` | `jazzsequence/action-validate-plugin-version@6b8b403af6e9eefde9c36c0d342b717d5952b518 # v2.0.1` | composite |
| `.github/workflows/wordpress-plugin-deploy.yml` | `actions/checkout@v5` | `actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1` | node24 |
| `.github/workflows/wordpress-plugin-deploy.yml` | `10up/action-wordpress-plugin-deploy@2.3.0` | `10up/action-wordpress-plugin-deploy@54bd289b8525fd23a5c365ec369185f2966529c2 # 2.3.0` | composite |
| `.github/workflows/wporg-validator.yml` | `shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1` | `shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2` | node20 |

Part of SITE-5791, under the CI standardization epic SITE-5778.

---

### Supersedes pending Dependabot PRs

This PR changes the same `uses:` lines as #505, now closed to avoid conflicting edits. Dependabot preserves whatever reference style it finds -- it bumps a tag to a newer tag and does not convert `@v4` into a SHA pin. The pinning has to happen here; Dependabot maintains the SHAs afterwards.


